### PR TITLE
Provide functions to replace == overloads (WIP)

### DIFF
--- a/Anchorage.xcodeproj/project.pbxproj
+++ b/Anchorage.xcodeproj/project.pbxproj
@@ -35,6 +35,7 @@
 		2DD2426D1D95C2CE001D6725 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 2DD2426C1D95C2CE001D6725 /* Assets.xcassets */; };
 		2DD242701D95C2CE001D6725 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 2DD2426E1D95C2CE001D6725 /* LaunchScreen.storyboard */; };
 		3C2050B71D3B213B00995DF3 /* Anchorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C2050B61D3B213B00995DF3 /* Anchorage.swift */; };
+		6370033C2280F3D800D5018F /* AnchorageFast.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6370033B2280F3D800D5018F /* AnchorageFast.swift */; };
 		7A39D6311EB53E1100BDE9C0 /* AnchorageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A39D6301EB53E1100BDE9C0 /* AnchorageTests.swift */; };
 		7A39D6331EB53E1100BDE9C0 /* Anchorage.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3C2050AB1D3B20FD00995DF3 /* Anchorage.framework */; };
 		BBE7C0D71FAB676F00DACD2D /* NSLayoutAnchor+MultiplierConstraints.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBE7C0D51FAB65B900DACD2D /* NSLayoutAnchor+MultiplierConstraints.swift */; };
@@ -107,6 +108,7 @@
 		3C2050AB1D3B20FD00995DF3 /* Anchorage.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Anchorage.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		3C2050AF1D3B20FD00995DF3 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		3C2050B61D3B213B00995DF3 /* Anchorage.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Anchorage.swift; sourceTree = "<group>"; };
+		6370033B2280F3D800D5018F /* AnchorageFast.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnchorageFast.swift; sourceTree = "<group>"; };
 		7A39D62E1EB53E1100BDE9C0 /* AnchorageTests-iOS.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "AnchorageTests-iOS.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		7A39D6301EB53E1100BDE9C0 /* AnchorageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnchorageTests.swift; sourceTree = "<group>"; };
 		7A39D6321EB53E1100BDE9C0 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -231,6 +233,7 @@
 			isa = PBXGroup;
 			children = (
 				3C2050B61D3B213B00995DF3 /* Anchorage.swift */,
+				6370033B2280F3D800D5018F /* AnchorageFast.swift */,
 				D469DCB61EB7A975000F3DDD /* AnchorGroupProvider.swift */,
 				D469DCB41EB7A904000F3DDD /* Priority.swift */,
 				D401673E1EB7A58D0025DCA5 /* Compatability.swift */,
@@ -464,6 +467,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 				Base,
 			);
@@ -602,6 +606,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				6370033C2280F3D800D5018F /* AnchorageFast.swift in Sources */,
 				2DBB2D4C1D99597500A1E94B /* MinimumWidthViewCell.swift in Sources */,
 				2DBB2D4E1D99597500A1E94B /* EdgeContainedLabelCell.swift in Sources */,
 				2DBB2D451D99596100A1E94B /* RootViewController.swift in Sources */,

--- a/Anchorage.xcodeproj/project.pbxproj
+++ b/Anchorage.xcodeproj/project.pbxproj
@@ -35,7 +35,9 @@
 		2DD2426D1D95C2CE001D6725 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 2DD2426C1D95C2CE001D6725 /* Assets.xcassets */; };
 		2DD242701D95C2CE001D6725 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 2DD2426E1D95C2CE001D6725 /* LaunchScreen.storyboard */; };
 		3C2050B71D3B213B00995DF3 /* Anchorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C2050B61D3B213B00995DF3 /* Anchorage.swift */; };
-		6370033C2280F3D800D5018F /* AnchorageFast.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6370033B2280F3D800D5018F /* AnchorageFast.swift */; };
+		63F09C412281DFBF00E2CC6A /* AnchorageFast.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6370033B2280F3D800D5018F /* AnchorageFast.swift */; };
+		63F09C422281DFC100E2CC6A /* AnchorageFast.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6370033B2280F3D800D5018F /* AnchorageFast.swift */; };
+		63F09C432281DFC200E2CC6A /* AnchorageFast.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6370033B2280F3D800D5018F /* AnchorageFast.swift */; };
 		7A39D6311EB53E1100BDE9C0 /* AnchorageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A39D6301EB53E1100BDE9C0 /* AnchorageTests.swift */; };
 		7A39D6331EB53E1100BDE9C0 /* Anchorage.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3C2050AB1D3B20FD00995DF3 /* Anchorage.framework */; };
 		BBE7C0D71FAB676F00DACD2D /* NSLayoutAnchor+MultiplierConstraints.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBE7C0D51FAB65B900DACD2D /* NSLayoutAnchor+MultiplierConstraints.swift */; };
@@ -108,7 +110,7 @@
 		3C2050AB1D3B20FD00995DF3 /* Anchorage.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Anchorage.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		3C2050AF1D3B20FD00995DF3 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		3C2050B61D3B213B00995DF3 /* Anchorage.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Anchorage.swift; sourceTree = "<group>"; };
-		6370033B2280F3D800D5018F /* AnchorageFast.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnchorageFast.swift; sourceTree = "<group>"; };
+		6370033B2280F3D800D5018F /* AnchorageFast.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnchorageFast.swift; sourceTree = "<group>"; };
 		7A39D62E1EB53E1100BDE9C0 /* AnchorageTests-iOS.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "AnchorageTests-iOS.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		7A39D6301EB53E1100BDE9C0 /* AnchorageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnchorageTests.swift; sourceTree = "<group>"; };
 		7A39D6321EB53E1100BDE9C0 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -606,7 +608,6 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				6370033C2280F3D800D5018F /* AnchorageFast.swift in Sources */,
 				2DBB2D4C1D99597500A1E94B /* MinimumWidthViewCell.swift in Sources */,
 				2DBB2D4E1D99597500A1E94B /* EdgeContainedLabelCell.swift in Sources */,
 				2DBB2D451D99596100A1E94B /* RootViewController.swift in Sources */,
@@ -626,6 +627,7 @@
 				BBE7C0D71FAB676F00DACD2D /* NSLayoutAnchor+MultiplierConstraints.swift in Sources */,
 				D401673D1EB7A4A30025DCA5 /* Internal.swift in Sources */,
 				D401673F1EB7A58D0025DCA5 /* Compatability.swift in Sources */,
+				63F09C412281DFBF00E2CC6A /* AnchorageFast.swift in Sources */,
 				D469DCB71EB7A975000F3DDD /* AnchorGroupProvider.swift in Sources */,
 				D469DCB51EB7A904000F3DDD /* Priority.swift in Sources */,
 			);
@@ -655,6 +657,7 @@
 				BBE7C0D91FAB677600DACD2D /* NSLayoutAnchor+MultiplierConstraints.swift in Sources */,
 				CD71F7A51EB7DD38008C1CC4 /* Anchorage.swift in Sources */,
 				CD71F7A61EB7DD38008C1CC4 /* AnchorGroupProvider.swift in Sources */,
+				63F09C432281DFC200E2CC6A /* AnchorageFast.swift in Sources */,
 				CD71F7A91EB7DD38008C1CC4 /* Internal.swift in Sources */,
 				CD71F7A71EB7DD38008C1CC4 /* Priority.swift in Sources */,
 			);
@@ -676,6 +679,7 @@
 				BBE7C0D81FAB677500DACD2D /* NSLayoutAnchor+MultiplierConstraints.swift in Sources */,
 				F154629B1E56846200C3948D /* Anchorage.swift in Sources */,
 				D40167411EB7A6270025DCA5 /* Compatability.swift in Sources */,
+				63F09C422281DFC100E2CC6A /* AnchorageFast.swift in Sources */,
 				D469DCB91EB7AB2F000F3DDD /* Priority.swift in Sources */,
 				D469DCB81EB7AB2F000F3DDD /* AnchorGroupProvider.swift in Sources */,
 			);

--- a/AnchorageDemo/Cells/AnimatableConstraintCell.swift
+++ b/AnchorageDemo/Cells/AnimatableConstraintCell.swift
@@ -64,13 +64,22 @@ private extension AnimatableConstraintCell {
     }
 
     func configureLayout() {
-        bodyLabel.topAnchor == contentView.topAnchor
-        bodyLabel.horizontalAnchors == contentView.horizontalAnchors + 10
+        bodyLabel.topAnchor.match(contentView.topAnchor)
+        bodyLabel.horizontalAnchors.match(contentView.horizontalAnchors + 10)
 
-        animatableView.topAnchor == bodyLabel.bottomAnchor + 10
-        animatableConstraint = animatableView.leadingAnchor == contentView.leadingAnchor
-        animatableView.widthAnchor == 20.0
-        animatableView.heightAnchor == 20.0
-        animatableView.bottomAnchor == contentView.bottomAnchor
+        animatableView.topAnchor.match(bodyLabel.bottomAnchor + 10)
+        animatableConstraint = animatableView.leadingAnchor.match(contentView.leadingAnchor)
+        animatableView.widthAnchor.match(20.0)
+        animatableView.heightAnchor.match(20.0)
+        animatableView.bottomAnchor.match(contentView.bottomAnchor)
+
+//        bodyLabel.topAnchor == contentView.topAnchor
+//        bodyLabel.horizontalAnchors == contentView.horizontalAnchors + 10
+//
+//        animatableView.topAnchor == bodyLabel.bottomAnchor + 10
+//        animatableConstraint = animatableView.leadingAnchor == contentView.leadingAnchor
+//        animatableView.widthAnchor == 20.0
+//        animatableView.heightAnchor == 20.0
+//        animatableView.bottomAnchor == contentView.bottomAnchor
     }
 }

--- a/AnchorageDemo/Cells/EdgeContainedLabelCell.swift
+++ b/AnchorageDemo/Cells/EdgeContainedLabelCell.swift
@@ -41,6 +41,8 @@ private extension EdgeContainedLabelCell {
     }
 
     func configureLayout() {
-        bodyLabel.edgeAnchors == contentView.edgeAnchors + 40
+//        bodyLabel.edgeAnchors == contentView.edgeAnchors + 40
+
+        bodyLabel.edgeAnchors.match(contentView.edgeAnchors + 40)
     }
 }

--- a/AnchorageDemo/Cells/EqualSpaceViewCell.swift
+++ b/AnchorageDemo/Cells/EqualSpaceViewCell.swift
@@ -57,27 +57,50 @@ private extension EqualSpaceViewCell {
     }
 
     func configureLayout() {
-        bodyLabel.topAnchor == contentView.topAnchor
-        bodyLabel.horizontalAnchors == contentView.horizontalAnchors + 10
+        bodyLabel.topAnchor.match(contentView.topAnchor)
+        bodyLabel.horizontalAnchors.match(contentView.horizontalAnchors + 10)
 
         guard let first = views.first, let last = views.last else {
             preconditionFailure("Empty views array in EqualSpaceViewCell")
         }
 
-        first.leadingAnchor == contentView.leadingAnchor
-        first.topAnchor == bodyLabel.bottomAnchor + 5
-        first.heightAnchor == 30
-        first.bottomAnchor == contentView.bottomAnchor
+        first.leadingAnchor.match(contentView.leadingAnchor)
+        first.topAnchor.match(bodyLabel.bottomAnchor + 5)
+        first.heightAnchor.match(30)
+        first.bottomAnchor.match(contentView.bottomAnchor)
 
         for i in 1..<views.count {
-            views[i].widthAnchor == first.widthAnchor
-            views[i].topAnchor == first.topAnchor
-            views[i].bottomAnchor == first.bottomAnchor
+            views[i].widthAnchor.match(first.widthAnchor)
+            views[i].topAnchor.match(first.topAnchor)
+            views[i].bottomAnchor.match(first.bottomAnchor)
             // Each view's leading anchor is at the previous view's trailing anchor.
             // As long as you're targeting iOS 9+, situations like this can often be handled with UIStackView.
-            spacingConstraints.append(views[i].leadingAnchor == views[i - 1].trailingAnchor)
+            spacingConstraints.append(views[i].leadingAnchor.match(views[i - 1].trailingAnchor))
         }
 
-        last.trailingAnchor == contentView.trailingAnchor
+        last.trailingAnchor.match(contentView.trailingAnchor)
+
+//        bodyLabel.topAnchor == contentView.topAnchor
+//        bodyLabel.horizontalAnchors == contentView.horizontalAnchors + 10
+//
+//        guard let first = views.first, let last = views.last else {
+//            preconditionFailure("Empty views array in EqualSpaceViewCell")
+//        }
+//
+//        first.leadingAnchor == contentView.leadingAnchor
+//        first.topAnchor == bodyLabel.bottomAnchor + 5
+//        first.heightAnchor == 30
+//        first.bottomAnchor == contentView.bottomAnchor
+//
+//        for i in 1..<views.count {
+//            views[i].widthAnchor == first.widthAnchor
+//            views[i].topAnchor == first.topAnchor
+//            views[i].bottomAnchor == first.bottomAnchor
+//            // Each view's leading anchor is at the previous view's trailing anchor.
+//            // As long as you're targeting iOS 9+, situations like this can often be handled with UIStackView.
+//            spacingConstraints.append(views[i].leadingAnchor == views[i - 1].trailingAnchor)
+//        }
+//
+//        last.trailingAnchor == contentView.trailingAnchor
     }
 }

--- a/AnchorageDemo/Cells/MinimumWidthViewCell.swift
+++ b/AnchorageDemo/Cells/MinimumWidthViewCell.swift
@@ -57,22 +57,40 @@ private extension MinimumWidthViewCell {
     }
 
     func configureLayout() {
-        bodyLabel.topAnchor == contentView.topAnchor + 10
-        bodyLabel.horizontalAnchors == contentView.horizontalAnchors + 10
+        bodyLabel.topAnchor.match(contentView.topAnchor + 10)
+        bodyLabel.horizontalAnchors.match(contentView.horizontalAnchors + 10)
 
-        blueWidthConstraint = (blueView.widthAnchor == 100)
-        blueView.centerXAnchor == centerXAnchor
-        blueView.topAnchor == bodyLabel.bottomAnchor + 5
-        blueView.heightAnchor == 10
+        blueWidthConstraint = (blueView.widthAnchor.match(100))
+        blueView.centerXAnchor.match(centerXAnchor)
+        blueView.topAnchor.match(bodyLabel.bottomAnchor + 5)
+        blueView.heightAnchor.match(10)
 
-        // We have 2 constraints that dictate the height of the red view. Auto layout tries to 
+        // We have 2 constraints that dictate the height of the red view. Auto layout tries to
         // satisfy both if possible, but if not, it'll satisfy the higher priority one.
-        redView.widthAnchor == blueView.widthAnchor * 0.5 ~ .low + 1
-        redView.widthAnchor <= 100 ~ .high
+        redView.widthAnchor.match(blueView.widthAnchor * 0.5 ~ .low + 1)
+        redView.widthAnchor.matchOrLess(100 ~ .high)
 
-        redView.heightAnchor == 10
-        redView.centerXAnchor == centerXAnchor
-        redView.topAnchor == blueView.bottomAnchor + 5
-        redView.bottomAnchor == contentView.bottomAnchor
+        redView.heightAnchor.match(10)
+        redView.centerXAnchor.match(centerXAnchor)
+        redView.topAnchor.match(blueView.bottomAnchor + 5)
+        redView.bottomAnchor.match(contentView.bottomAnchor)
+
+//        bodyLabel.topAnchor == contentView.topAnchor + 10
+//        bodyLabel.horizontalAnchors == contentView.horizontalAnchors + 10
+//
+//        blueWidthConstraint = (blueView.widthAnchor == 100)
+//        blueView.centerXAnchor == centerXAnchor
+//        blueView.topAnchor == bodyLabel.bottomAnchor + 5
+//        blueView.heightAnchor == 10
+//
+//        // We have 2 constraints that dictate the height of the red view. Auto layout tries to
+//        // satisfy both if possible, but if not, it'll satisfy the higher priority one.
+//        redView.widthAnchor == blueView.widthAnchor * 0.5 ~ .low + 1
+//        redView.widthAnchor <= 100 ~ .high
+//
+//        redView.heightAnchor == 10
+//        redView.centerXAnchor == centerXAnchor
+//        redView.topAnchor == blueView.bottomAnchor + 5
+//        redView.bottomAnchor == contentView.bottomAnchor
     }
 }

--- a/AnchorageDemo/Cells/ToggleActiveHeightCell.swift
+++ b/AnchorageDemo/Cells/ToggleActiveHeightCell.swift
@@ -59,19 +59,34 @@ private extension ToggleActiveHeightCell {
     }
 
     func configureLayout() {
-        bodyLabel.topAnchor == contentView.topAnchor
-        bodyLabel.horizontalAnchors == contentView.horizontalAnchors + 10
+        bodyLabel.topAnchor.match(contentView.topAnchor)
+        bodyLabel.horizontalAnchors.match(contentView.horizontalAnchors + 10)
 
-        leftView.leftAnchor == contentView.leftAnchor
-        leftView.rightAnchor == contentView.centerXAnchor
-        leftView.topAnchor == bodyLabel.bottomAnchor + 5
-        leftView.heightAnchor == 30
-        leftView.bottomAnchor == contentView.bottomAnchor
+        leftView.leftAnchor.match(contentView.leftAnchor)
+        leftView.rightAnchor.match(contentView.centerXAnchor)
+        leftView.topAnchor.match(bodyLabel.bottomAnchor + 5)
+        leftView.heightAnchor.match(30)
+        leftView.bottomAnchor.match(contentView.bottomAnchor)
 
-        rightView.leftAnchor == contentView.centerXAnchor
-        rightView.rightAnchor == contentView.rightAnchor
-        rightView.topAnchor == leftView.topAnchor
+        rightView.leftAnchor.match(contentView.centerXAnchor)
+        rightView.rightAnchor.match(contentView.rightAnchor)
+        rightView.topAnchor.match(leftView.topAnchor)
         // When we set this to inactive, there is no specification for this view's height, so it is zero.
-        rightHeightConstraint = (rightView.heightAnchor == leftView.heightAnchor)
+        rightHeightConstraint = (rightView.heightAnchor.match(leftView.heightAnchor))
+
+//        bodyLabel.topAnchor == contentView.topAnchor
+//        bodyLabel.horizontalAnchors == contentView.horizontalAnchors + 10
+//
+//        leftView.leftAnchor == contentView.leftAnchor
+//        leftView.rightAnchor == contentView.centerXAnchor
+//        leftView.topAnchor == bodyLabel.bottomAnchor + 5
+//        leftView.heightAnchor == 30
+//        leftView.bottomAnchor == contentView.bottomAnchor
+//
+//        rightView.leftAnchor == contentView.centerXAnchor
+//        rightView.rightAnchor == contentView.rightAnchor
+//        rightView.topAnchor == leftView.topAnchor
+//        // When we set this to inactive, there is no specification for this view's height, so it is zero.
+//        rightHeightConstraint = (rightView.heightAnchor == leftView.heightAnchor)
     }
 }

--- a/Source/AnchorageFast.swift
+++ b/Source/AnchorageFast.swift
@@ -1,0 +1,439 @@
+//
+//  AnchorageFast.swift
+//  AnchorageDemo
+//
+//  Created by Chad on 5/6/19.
+//  Copyright © 2019 Raizlabs. All rights reserved.
+//
+
+#if os(macOS)
+import Cocoa
+#else
+import UIKit
+#endif
+
+//public protocol LayoutConstantType {}
+//extension CGFloat: LayoutConstantType {}
+//extension CGSize: LayoutConstantType {}
+//extension EdgeInsets: LayoutConstantType {}
+
+//public protocol LayoutAnchorType {}
+//extension NSLayoutAnchor: LayoutAnchorType {}
+
+// MARK: - Equality Constraints
+extension NSLayoutDimension {
+    @discardableResult public func match<T: BinaryFloatingPoint>(_ rhs: T) -> NSLayoutConstraint {
+        return finalize(constraint: self.constraint(equalToConstant: CGFloat(rhs)))
+    }
+
+    @discardableResult public func match(_ rhs: NSLayoutDimension) -> NSLayoutConstraint {
+        return finalize(constraint: self.constraint(equalTo: rhs))
+    }
+
+    @discardableResult public func match(_ rhs: LayoutExpression<NSLayoutDimension, CGFloat>) -> NSLayoutConstraint {
+        if let anchor = rhs.anchor {
+            return finalize(constraint: self.constraint(equalTo: anchor, multiplier: rhs.multiplier, constant: rhs.constant), withPriority: rhs.priority)
+        }
+        else {
+            return finalize(constraint: self.constraint(equalToConstant: rhs.constant), withPriority: rhs.priority)
+        }
+    }
+}
+
+extension NSLayoutXAxisAnchor {
+    @discardableResult public func match(_ rhs: NSLayoutXAxisAnchor) -> NSLayoutConstraint {
+        return finalize(constraint: self.constraint(equalTo: rhs))
+    }
+
+    @discardableResult public func match(_ rhs: LayoutExpression<NSLayoutXAxisAnchor, CGFloat>) -> NSLayoutConstraint {
+        return finalize(constraint: self.constraint(equalTo: rhs.anchor!, multiplier: rhs.multiplier, constant: rhs.constant), withPriority: rhs.priority)
+    }
+}
+
+extension NSLayoutYAxisAnchor {
+    @discardableResult public func match(_ rhs: NSLayoutYAxisAnchor) -> NSLayoutConstraint {
+        return finalize(constraint: self.constraint(equalTo: rhs))
+    }
+
+    @discardableResult public func match(_ rhs: LayoutExpression<NSLayoutYAxisAnchor, CGFloat>) -> NSLayoutConstraint {
+        return finalize(constraint: self.constraint(equalTo: rhs.anchor!, multiplier: rhs.multiplier, constant: rhs.constant), withPriority: rhs.priority)
+    }
+}
+
+
+extension EdgeAnchors {
+    @discardableResult public func match(_ rhs: EdgeAnchors) -> ConstraintGroup {
+        return self.finalize(constraintsEqualToEdges: rhs)
+    }
+
+    @discardableResult public func match(_ rhs: LayoutExpression<EdgeAnchors, CGFloat>) -> ConstraintGroup {
+        return self.finalize(constraintsEqualToEdges: rhs.anchor, constant: rhs.constant, priority: rhs.priority)
+    }
+
+    @discardableResult public func match(_ rhs: LayoutExpression<EdgeAnchors, EdgeInsets>) -> ConstraintGroup {
+        return self.finalize(constraintsEqualToEdges: rhs.anchor, insets: rhs.constant, priority: rhs.priority)
+    }
+}
+
+extension AnchorPair {
+    @discardableResult public func match(_ rhs: AnchorPair<T, U>) -> ConstraintPair {
+        return self.finalize(constraintsEqualToEdges: rhs)
+    }
+
+    @discardableResult public func match(_ rhs: LayoutExpression<AnchorPair<T, U>, CGFloat>) -> ConstraintPair {
+        return self.finalize(constraintsEqualToEdges: rhs.anchor, constant: rhs.constant, priority: rhs.priority)
+    }
+
+    @discardableResult public func match(_ rhs: CGSize) -> ConstraintPair
+        where T: NSLayoutDimension, U: NSLayoutDimension {
+        return self.finalize(constraintsEqualToConstant: rhs)
+    }
+
+    @discardableResult public func match(_ rhs: LayoutExpression<AnchorPair<NSLayoutDimension, NSLayoutDimension>, CGSize>) -> ConstraintPair
+        where T: NSLayoutDimension, U: NSLayoutDimension {
+        return self.finalize(constraintsEqualToConstant: rhs.constant, priority: rhs.priority)
+    }
+}
+
+
+
+// MARK: - Inequality Constraints
+// less than
+extension NSLayoutDimension {
+    @discardableResult public func matchLess<T: BinaryFloatingPoint>(_ rhs: T) -> NSLayoutConstraint {
+        return finalize(constraint: self.constraint(lessThanOrEqualToConstant: CGFloat(rhs)))
+    }
+
+    @discardableResult public func matchLess(_ rhs: NSLayoutDimension) -> NSLayoutConstraint {
+        return finalize(constraint: self.constraint(lessThanOrEqualTo: rhs))
+    }
+
+    @discardableResult public func matchLess(_ rhs: LayoutExpression<NSLayoutDimension, CGFloat>) -> NSLayoutConstraint {
+        if let anchor = rhs.anchor {
+            return finalize(constraint: self.constraint(lessThanOrEqualTo: anchor, multiplier: rhs.multiplier, constant: rhs.constant), withPriority: rhs.priority)
+        }
+        else {
+            return finalize(constraint: self.constraint(lessThanOrEqualToConstant: rhs.constant), withPriority: rhs.priority)
+        }
+    }
+}
+
+extension NSLayoutXAxisAnchor {
+    @discardableResult public func matchLess(_ rhs: NSLayoutXAxisAnchor) -> NSLayoutConstraint {
+        return finalize(constraint: self.constraint(lessThanOrEqualTo: rhs))
+    }
+
+    @discardableResult public func matchLess(_ rhs: LayoutExpression<NSLayoutXAxisAnchor, CGFloat>) -> NSLayoutConstraint {
+        return finalize(constraint: self.constraint(lessThanOrEqualTo: rhs.anchor!, multiplier: rhs.multiplier, constant: rhs.constant), withPriority: rhs.priority)
+    }
+}
+
+extension NSLayoutYAxisAnchor {
+    @discardableResult public func matchLess(_ rhs: NSLayoutYAxisAnchor) -> NSLayoutConstraint {
+        return finalize(constraint: self.constraint(lessThanOrEqualTo: rhs))
+    }
+
+    @discardableResult public func matchLess(_ rhs: LayoutExpression<NSLayoutYAxisAnchor, CGFloat>) -> NSLayoutConstraint {
+        return finalize(constraint: self.constraint(lessThanOrEqualTo: rhs.anchor!, multiplier: rhs.multiplier, constant: rhs.constant), withPriority: rhs.priority)
+    }
+}
+
+extension EdgeAnchors {
+    @discardableResult public func matchLess(_ rhs: EdgeAnchors) -> ConstraintGroup {
+        return self.finalize(constraintsLessThanOrEqualToEdges: rhs)
+    }
+
+    @discardableResult public func matchLess(_ rhs: LayoutExpression<EdgeAnchors, CGFloat>) -> ConstraintGroup {
+        return self.finalize(constraintsLessThanOrEqualToEdges: rhs.anchor, constant: rhs.constant, priority: rhs.priority)
+    }
+
+    @discardableResult public func matchLess(_ rhs: LayoutExpression<EdgeAnchors, EdgeInsets>) -> ConstraintGroup {
+        return self.finalize(constraintsLessThanOrEqualToEdges: rhs.anchor, insets: rhs.constant, priority: rhs.priority)
+    }
+}
+
+extension AnchorPair {
+    @discardableResult public func matchLess(_ rhs: AnchorPair<T, U>) -> ConstraintPair {
+        return self.finalize(constraintsLessThanOrEqualToEdges: rhs)
+    }
+
+    @discardableResult public func matchLess(_ rhs: LayoutExpression<AnchorPair<T, U>, CGFloat>) -> ConstraintPair {
+        return self.finalize(constraintsLessThanOrEqualToEdges: rhs.anchor, constant: rhs.constant, priority: rhs.priority)
+    }
+
+    @discardableResult public func matchLess(_ rhs: CGSize) -> ConstraintPair
+        where T: NSLayoutDimension, U: NSLayoutDimension {
+        return self.finalize(constraintsLessThanOrEqualToConstant: rhs)
+    }
+
+    @discardableResult public func matchLess(_ rhs: LayoutExpression<AnchorPair<NSLayoutDimension, NSLayoutDimension>, CGSize>) -> ConstraintPair
+        where T: NSLayoutDimension, U: NSLayoutDimension {
+        return self.finalize(constraintsLessThanOrEqualToConstant: rhs.constant, priority: rhs.priority)
+    }
+}
+// Greater than
+extension NSLayoutDimension {
+    @discardableResult public func matchGreater<T: BinaryFloatingPoint>(_ rhs: T) -> NSLayoutConstraint {
+        return finalize(constraint: self.constraint(greaterThanOrEqualToConstant: CGFloat(rhs)))
+    }
+
+    @discardableResult public func matchGreater(_ rhs: NSLayoutDimension) -> NSLayoutConstraint {
+        return finalize(constraint: self.constraint(greaterThanOrEqualTo: rhs))
+    }
+
+    @discardableResult public func matchGreater(_ rhs: LayoutExpression<NSLayoutDimension, CGFloat>) -> NSLayoutConstraint {
+        if let anchor = rhs.anchor {
+            return finalize(constraint: self.constraint(greaterThanOrEqualTo: anchor, multiplier: rhs.multiplier, constant: rhs.constant), withPriority: rhs.priority)
+        }
+        else {
+            return finalize(constraint: self.constraint(greaterThanOrEqualToConstant: rhs.constant), withPriority: rhs.priority)
+        }
+    }
+}
+
+extension NSLayoutXAxisAnchor {
+    @discardableResult public func matchGreater(_ rhs: NSLayoutXAxisAnchor) -> NSLayoutConstraint {
+        return finalize(constraint: self.constraint(greaterThanOrEqualTo: rhs))
+    }
+
+    @discardableResult public func matchGreater(_ rhs: LayoutExpression<NSLayoutXAxisAnchor, CGFloat>) -> NSLayoutConstraint {
+        return finalize(constraint: self.constraint(greaterThanOrEqualTo: rhs.anchor!, multiplier: rhs.multiplier, constant: rhs.constant), withPriority: rhs.priority)
+    }
+}
+
+extension NSLayoutYAxisAnchor {
+    @discardableResult public func matchGreater(_ rhs: NSLayoutYAxisAnchor) -> NSLayoutConstraint {
+        return finalize(constraint: self.constraint(greaterThanOrEqualTo: rhs))
+    }
+
+    @discardableResult public func >= (_ rhs: LayoutExpression<NSLayoutYAxisAnchor, CGFloat>) -> NSLayoutConstraint {
+        return finalize(constraint: self.constraint(greaterThanOrEqualTo: rhs.anchor!, multiplier: rhs.multiplier, constant: rhs.constant), withPriority: rhs.priority)
+    }
+}
+
+
+//
+//@discardableResult public func >= (lhs: EdgeAnchors, rhs: EdgeAnchors) -> ConstraintGroup {
+//    return lhs.finalize(constraintsGreaterThanOrEqualToEdges: rhs)
+//}
+//
+//@discardableResult public func >= (lhs: EdgeAnchors, rhs: LayoutExpression<EdgeAnchors, CGFloat>) -> ConstraintGroup {
+//    return lhs.finalize(constraintsGreaterThanOrEqualToEdges: rhs.anchor, constant: rhs.constant, priority: rhs.priority)
+//}
+//
+//@discardableResult public func >= (lhs: EdgeAnchors, rhs: LayoutExpression<EdgeAnchors, EdgeInsets>) -> ConstraintGroup {
+//    return lhs.finalize(constraintsGreaterThanOrEqualToEdges: rhs.anchor, insets: rhs.constant, priority: rhs.priority)
+//}
+//
+//@discardableResult public func >= <T, U>(lhs: AnchorPair<T, U>, rhs: AnchorPair<T, U>) -> ConstraintPair {
+//    return lhs.finalize(constraintsGreaterThanOrEqualToEdges: rhs)
+//}
+//
+//@discardableResult public func >= <T, U>(lhs: AnchorPair<T, U>, rhs: LayoutExpression<AnchorPair<T, U>, CGFloat>) -> ConstraintPair {
+//    return lhs.finalize(constraintsGreaterThanOrEqualToEdges: rhs.anchor, constant: rhs.constant, priority: rhs.priority)
+//}
+//
+//@discardableResult public func >= (lhs: AnchorPair<NSLayoutDimension, NSLayoutDimension>, rhs: CGSize) -> ConstraintPair {
+//    return lhs.finalize(constraintsGreaterThanOrEqualToConstant: rhs)
+//}
+//
+//@discardableResult public func >= (lhs: AnchorPair<NSLayoutDimension, NSLayoutDimension>, rhs: LayoutExpression<AnchorPair<NSLayoutDimension, NSLayoutDimension>, CGSize>) -> ConstraintPair {
+//    return lhs.finalize(constraintsGreaterThanOrEqualToConstant: rhs.constant, priority: rhs.priority)
+//}
+//
+//// MARK: - Priority
+//
+//precedencegroup PriorityPrecedence {
+//    associativity: none
+//    higherThan: ComparisonPrecedence
+//    lowerThan: AdditionPrecedence
+//}
+//
+//infix operator ~: PriorityPrecedence
+//
+//@discardableResult public func ~ <T: BinaryFloatingPoint>(lhs: T, rhs: Priority) -> LayoutExpression<NSLayoutDimension, CGFloat> {
+//    return LayoutExpression(constant: CGFloat(lhs), priority: rhs)
+//}
+//
+//@discardableResult public func ~ (lhs: CGSize, rhs: Priority) -> LayoutExpression<AnchorPair<NSLayoutDimension, NSLayoutDimension>, CGSize> {
+//    return LayoutExpression(constant: lhs, priority: rhs)
+//}
+//
+//@discardableResult public func ~ <T>(lhs: T, rhs: Priority) -> LayoutExpression<T, CGFloat> {
+//    return LayoutExpression(anchor: lhs, constant: 0.0, priority: rhs)
+//}
+//
+//@discardableResult public func ~ <T, U>(lhs: LayoutExpression<T, U>, rhs: Priority) -> LayoutExpression<T, U> {
+//    var expr = lhs
+//    expr.priority = rhs
+//    return expr
+//}
+//
+//@discardableResult public func * <T: BinaryFloatingPoint>(lhs: NSLayoutDimension, rhs: T) -> LayoutExpression<NSLayoutDimension, CGFloat> {
+//    return LayoutExpression(anchor: lhs, constant: 0.0, multiplier: CGFloat(rhs))
+//}
+//
+//@discardableResult public func * <T: BinaryFloatingPoint>(lhs: T, rhs: NSLayoutDimension) -> LayoutExpression<NSLayoutDimension, CGFloat> {
+//    return LayoutExpression(anchor: rhs, constant: 0.0, multiplier: CGFloat(lhs))
+//}
+//
+//@discardableResult public func * <T: BinaryFloatingPoint>(lhs: LayoutExpression<NSLayoutDimension, CGFloat>, rhs: T) -> LayoutExpression<NSLayoutDimension, CGFloat> {
+//    var expr = lhs
+//    expr.multiplier *= CGFloat(rhs)
+//    return expr
+//}
+//
+//@discardableResult public func * <T: BinaryFloatingPoint>(lhs: T, rhs: LayoutExpression<NSLayoutDimension, CGFloat>) -> LayoutExpression<NSLayoutDimension, CGFloat> {
+//    var expr = rhs
+//    expr.multiplier *= CGFloat(lhs)
+//    return expr
+//}
+//
+//@discardableResult public func * <T: BinaryFloatingPoint>(lhs: NSLayoutXAxisAnchor, rhs: T) -> LayoutExpression<NSLayoutXAxisAnchor, CGFloat> {
+//    return LayoutExpression(anchor: Optional<NSLayoutXAxisAnchor>.some(lhs), constant: 0.0, multiplier: CGFloat(rhs))
+//}
+//
+//@discardableResult public func * <T: BinaryFloatingPoint>(lhs: T, rhs: NSLayoutXAxisAnchor) -> LayoutExpression<NSLayoutXAxisAnchor, CGFloat> {
+//    return LayoutExpression(anchor: rhs, constant: 0.0, multiplier: CGFloat(lhs))
+//}
+//
+//@discardableResult public func * <T: BinaryFloatingPoint>(lhs: LayoutExpression<NSLayoutXAxisAnchor, CGFloat>, rhs: T) -> LayoutExpression<NSLayoutXAxisAnchor, CGFloat> {
+//    var expr = lhs
+//    expr.multiplier *= CGFloat(rhs)
+//    return expr
+//}
+//
+//@discardableResult public func * <T: BinaryFloatingPoint>(lhs: T, rhs: LayoutExpression<NSLayoutXAxisAnchor, CGFloat>) -> LayoutExpression<NSLayoutXAxisAnchor, CGFloat> {
+//    var expr = rhs
+//    expr.multiplier *= CGFloat(lhs)
+//    return expr
+//}
+//
+//@discardableResult public func * <T: BinaryFloatingPoint>(lhs: NSLayoutYAxisAnchor, rhs: T) -> LayoutExpression<NSLayoutYAxisAnchor, CGFloat> {
+//    return LayoutExpression(anchor: lhs, constant: 0.0, multiplier: CGFloat(rhs))
+//}
+//
+//@discardableResult public func * <T: BinaryFloatingPoint>(lhs: T, rhs: NSLayoutYAxisAnchor) -> LayoutExpression<NSLayoutYAxisAnchor, CGFloat> {
+//    return LayoutExpression(anchor: rhs, constant: 0.0, multiplier: CGFloat(lhs))
+//}
+//
+//@discardableResult public func * <T: BinaryFloatingPoint>(lhs: LayoutExpression<NSLayoutYAxisAnchor, CGFloat>, rhs: T) -> LayoutExpression<NSLayoutYAxisAnchor, CGFloat> {
+//    var expr = lhs
+//    expr.multiplier *= CGFloat(rhs)
+//    return expr
+//}
+//
+//@discardableResult public func * <T: BinaryFloatingPoint>(lhs: T, rhs: LayoutExpression<NSLayoutYAxisAnchor, CGFloat>) -> LayoutExpression<NSLayoutYAxisAnchor, CGFloat> {
+//    var expr = rhs
+//    expr.multiplier *= CGFloat(lhs)
+//    return expr
+//}
+//
+//@discardableResult public func / <T: BinaryFloatingPoint>(lhs: NSLayoutDimension, rhs: T) -> LayoutExpression<NSLayoutDimension, CGFloat> {
+//    return LayoutExpression(anchor: lhs, constant: 0.0, multiplier: 1.0 / CGFloat(rhs))
+//}
+//
+//@discardableResult public func / <T: BinaryFloatingPoint>(lhs: LayoutExpression<NSLayoutDimension, CGFloat>, rhs: T) -> LayoutExpression<NSLayoutDimension, CGFloat> {
+//    var expr = lhs
+//    expr.multiplier /= CGFloat(rhs)
+//    return expr
+//}
+//
+//@discardableResult public func / <T: BinaryFloatingPoint>(lhs: NSLayoutXAxisAnchor, rhs: T) -> LayoutExpression<NSLayoutXAxisAnchor, CGFloat> {
+//    return LayoutExpression(anchor: lhs, constant: 0.0, multiplier: 1.0 / CGFloat(rhs))
+//}
+//
+//@discardableResult public func / <T: BinaryFloatingPoint>(lhs: LayoutExpression<NSLayoutXAxisAnchor, CGFloat>, rhs: T) -> LayoutExpression<NSLayoutXAxisAnchor, CGFloat> {
+//    var expr = lhs
+//    expr.multiplier /= CGFloat(rhs)
+//    return expr
+//}
+//
+//@discardableResult public func / <T: BinaryFloatingPoint>(lhs: NSLayoutYAxisAnchor, rhs: T) -> LayoutExpression<NSLayoutYAxisAnchor, CGFloat> {
+//    return LayoutExpression(anchor: lhs, constant: 0.0, multiplier: 1.0 / CGFloat(rhs))
+//}
+//
+//@discardableResult public func / <T: BinaryFloatingPoint>(lhs: LayoutExpression<NSLayoutYAxisAnchor, CGFloat>, rhs: T) -> LayoutExpression<NSLayoutYAxisAnchor, CGFloat> {
+//    var expr = lhs
+//    expr.multiplier /= CGFloat(rhs)
+//    return expr
+//}
+//
+//@discardableResult public func + <T, U: BinaryFloatingPoint>(lhs: T, rhs: U) -> LayoutExpression<T, CGFloat> {
+//    return LayoutExpression(anchor: lhs, constant: CGFloat(rhs))
+//}
+//
+//@discardableResult public func + <T: BinaryFloatingPoint, U>(lhs: T, rhs: U) -> LayoutExpression<U, CGFloat> {
+//    return LayoutExpression(anchor: rhs, constant: CGFloat(lhs))
+//}
+//
+//@discardableResult public func + <T, U: BinaryFloatingPoint>(lhs: LayoutExpression<T, CGFloat>, rhs: U) -> LayoutExpression<T, CGFloat> {
+//    var expr = lhs
+//    expr.constant += CGFloat(rhs)
+//    return expr
+//}
+//
+//@discardableResult public func + <T: BinaryFloatingPoint, U>(lhs: T, rhs: LayoutExpression<U, CGFloat>) -> LayoutExpression<U, CGFloat> {
+//    var expr = rhs
+//    expr.constant += CGFloat(lhs)
+//    return expr
+//}
+//
+//@discardableResult public func + (lhs: EdgeAnchors, rhs: EdgeInsets) -> LayoutExpression<EdgeAnchors, EdgeInsets> {
+//    return LayoutExpression(anchor: lhs, constant: rhs)
+//}
+//
+//@discardableResult public func - <T, U: BinaryFloatingPoint>(lhs: T, rhs: U) -> LayoutExpression<T, CGFloat> {
+//    return LayoutExpression(anchor: lhs, constant: -CGFloat(rhs))
+//}
+//
+//@discardableResult public func - <T: BinaryFloatingPoint, U>(lhs: T, rhs: U) -> LayoutExpression<U, CGFloat> {
+//    return LayoutExpression(anchor: rhs, constant: -CGFloat(lhs))
+//}
+//
+//@discardableResult public func - <T, U: BinaryFloatingPoint>(lhs: LayoutExpression<T, CGFloat>, rhs: U) -> LayoutExpression<T, CGFloat> {
+//    var expr = lhs
+//    expr.constant -= CGFloat(rhs)
+//    return expr
+//}
+//
+//@discardableResult public func - <T: BinaryFloatingPoint, U>(lhs: T, rhs: LayoutExpression<U, CGFloat>) -> LayoutExpression<U, CGFloat> {
+//    var expr = rhs
+//    expr.constant -= CGFloat(lhs)
+//    return expr
+//}
+//
+//@discardableResult public func - (lhs: EdgeAnchors, rhs: EdgeInsets) -> LayoutExpression<EdgeAnchors, EdgeInsets> {
+//    return LayoutExpression(anchor: lhs, constant: -rhs)
+//}
+//
+//// MARK: - Batching
+//
+///// Any Anchorage constraints created inside the passed closure are returned in the array.
+/////
+///// - Parameter closure: A closure that runs some Anchorage expressions.
+///// - Returns: An array of new, active `NSLayoutConstraint`s.
+//@discardableResult public func batch(_ closure: () -> Void) -> [NSLayoutConstraint] {
+//    return batch(active: true, closure: closure)
+//}
+//
+///// Any Anchorage constraints created inside the passed closure are returned in the array.
+/////
+///// - Parameter active: Whether the created constraints should be active when they are returned.
+///// - Parameter closure: A closure that runs some Anchorage expressions.
+///// - Returns: An array of new `NSLayoutConstraint`s.
+//public func batch(active: Bool, closure: () -> Void) -> [NSLayoutConstraint] {
+//    let batch = ConstraintBatch()
+//    batches.append(batch)
+//    defer {
+//        batches.removeLast()
+//    }
+//
+//    closure()
+//
+//    if active {
+//        batch.activate()
+//    }
+//
+//    return batch.constraints
+//}

--- a/Source/AnchorageFast.swift
+++ b/Source/AnchorageFast.swift
@@ -23,40 +23,40 @@ import UIKit
 // MARK: - Equality Constraints
 extension NSLayoutDimension {
     @discardableResult public func match<T: BinaryFloatingPoint>(_ rhs: T) -> NSLayoutConstraint {
-        return finalize(constraint: self.constraint(equalToConstant: CGFloat(rhs)))
+        return Anchorage.finalize(constraint: self.constraint(equalToConstant: CGFloat(rhs)))
     }
 
     @discardableResult public func match(_ rhs: NSLayoutDimension) -> NSLayoutConstraint {
-        return finalize(constraint: self.constraint(equalTo: rhs))
+        return Anchorage.finalize(constraint: self.constraint(equalTo: rhs))
     }
 
     @discardableResult public func match(_ rhs: LayoutExpression<NSLayoutDimension, CGFloat>) -> NSLayoutConstraint {
         if let anchor = rhs.anchor {
-            return finalize(constraint: self.constraint(equalTo: anchor, multiplier: rhs.multiplier, constant: rhs.constant), withPriority: rhs.priority)
+            return Anchorage.finalize(constraint: self.constraint(equalTo: anchor, multiplier: rhs.multiplier, constant: rhs.constant), withPriority: rhs.priority)
         }
         else {
-            return finalize(constraint: self.constraint(equalToConstant: rhs.constant), withPriority: rhs.priority)
+            return Anchorage.finalize(constraint: self.constraint(equalToConstant: rhs.constant), withPriority: rhs.priority)
         }
     }
 }
 
 extension NSLayoutXAxisAnchor {
     @discardableResult public func match(_ rhs: NSLayoutXAxisAnchor) -> NSLayoutConstraint {
-        return finalize(constraint: self.constraint(equalTo: rhs))
+        return Anchorage.finalize(constraint: self.constraint(equalTo: rhs))
     }
 
     @discardableResult public func match(_ rhs: LayoutExpression<NSLayoutXAxisAnchor, CGFloat>) -> NSLayoutConstraint {
-        return finalize(constraint: self.constraint(equalTo: rhs.anchor!, multiplier: rhs.multiplier, constant: rhs.constant), withPriority: rhs.priority)
+        return Anchorage.finalize(constraint: self.constraint(equalTo: rhs.anchor!, multiplier: rhs.multiplier, constant: rhs.constant), withPriority: rhs.priority)
     }
 }
 
 extension NSLayoutYAxisAnchor {
     @discardableResult public func match(_ rhs: NSLayoutYAxisAnchor) -> NSLayoutConstraint {
-        return finalize(constraint: self.constraint(equalTo: rhs))
+        return Anchorage.finalize(constraint: self.constraint(equalTo: rhs))
     }
 
     @discardableResult public func match(_ rhs: LayoutExpression<NSLayoutYAxisAnchor, CGFloat>) -> NSLayoutConstraint {
-        return finalize(constraint: self.constraint(equalTo: rhs.anchor!, multiplier: rhs.multiplier, constant: rhs.constant), withPriority: rhs.priority)
+        return Anchorage.finalize(constraint: self.constraint(equalTo: rhs.anchor!, multiplier: rhs.multiplier, constant: rhs.constant), withPriority: rhs.priority)
     }
 }
 
@@ -83,164 +83,167 @@ extension AnchorPair {
     @discardableResult public func match(_ rhs: LayoutExpression<AnchorPair<T, U>, CGFloat>) -> ConstraintPair {
         return self.finalize(constraintsEqualToEdges: rhs.anchor, constant: rhs.constant, priority: rhs.priority)
     }
+}
 
-    @discardableResult public func match(_ rhs: CGSize) -> ConstraintPair
-        where T: NSLayoutDimension, U: NSLayoutDimension {
+extension AnchorPair where T: NSLayoutDimension, U: NSLayoutDimension {
+    @discardableResult public func match(_ rhs: CGSize) -> ConstraintPair {
         return self.finalize(constraintsEqualToConstant: rhs)
     }
 
-    @discardableResult public func match(_ rhs: LayoutExpression<AnchorPair<NSLayoutDimension, NSLayoutDimension>, CGSize>) -> ConstraintPair
-        where T: NSLayoutDimension, U: NSLayoutDimension {
+    @discardableResult public func match(_ rhs: LayoutExpression<AnchorPair<NSLayoutDimension, NSLayoutDimension>, CGSize>) -> ConstraintPair {
         return self.finalize(constraintsEqualToConstant: rhs.constant, priority: rhs.priority)
     }
 }
 
-
-
 // MARK: - Inequality Constraints
 // less than
 extension NSLayoutDimension {
-    @discardableResult public func matchLess<T: BinaryFloatingPoint>(_ rhs: T) -> NSLayoutConstraint {
-        return finalize(constraint: self.constraint(lessThanOrEqualToConstant: CGFloat(rhs)))
+    @discardableResult public func matchOrLess<T: BinaryFloatingPoint>(_ rhs: T) -> NSLayoutConstraint {
+        return Anchorage.finalize(constraint: self.constraint(lessThanOrEqualToConstant: CGFloat(rhs)))
     }
 
-    @discardableResult public func matchLess(_ rhs: NSLayoutDimension) -> NSLayoutConstraint {
-        return finalize(constraint: self.constraint(lessThanOrEqualTo: rhs))
+    @discardableResult public func matchOrLess(_ rhs: NSLayoutDimension) -> NSLayoutConstraint {
+        return Anchorage.finalize(constraint: self.constraint(lessThanOrEqualTo: rhs))
     }
 
-    @discardableResult public func matchLess(_ rhs: LayoutExpression<NSLayoutDimension, CGFloat>) -> NSLayoutConstraint {
+    @discardableResult public func matchOrLess(_ rhs: LayoutExpression<NSLayoutDimension, CGFloat>) -> NSLayoutConstraint {
         if let anchor = rhs.anchor {
-            return finalize(constraint: self.constraint(lessThanOrEqualTo: anchor, multiplier: rhs.multiplier, constant: rhs.constant), withPriority: rhs.priority)
+            return Anchorage.finalize(constraint: self.constraint(lessThanOrEqualTo: anchor, multiplier: rhs.multiplier, constant: rhs.constant), withPriority: rhs.priority)
         }
         else {
-            return finalize(constraint: self.constraint(lessThanOrEqualToConstant: rhs.constant), withPriority: rhs.priority)
+            return Anchorage.finalize(constraint: self.constraint(lessThanOrEqualToConstant: rhs.constant), withPriority: rhs.priority)
         }
     }
 }
 
 extension NSLayoutXAxisAnchor {
-    @discardableResult public func matchLess(_ rhs: NSLayoutXAxisAnchor) -> NSLayoutConstraint {
-        return finalize(constraint: self.constraint(lessThanOrEqualTo: rhs))
+    @discardableResult public func matchOrLess(_ rhs: NSLayoutXAxisAnchor) -> NSLayoutConstraint {
+        return Anchorage.finalize(constraint: self.constraint(lessThanOrEqualTo: rhs))
     }
 
-    @discardableResult public func matchLess(_ rhs: LayoutExpression<NSLayoutXAxisAnchor, CGFloat>) -> NSLayoutConstraint {
-        return finalize(constraint: self.constraint(lessThanOrEqualTo: rhs.anchor!, multiplier: rhs.multiplier, constant: rhs.constant), withPriority: rhs.priority)
+    @discardableResult public func matchOrLess(_ rhs: LayoutExpression<NSLayoutXAxisAnchor, CGFloat>) -> NSLayoutConstraint {
+        return Anchorage.finalize(constraint: self.constraint(lessThanOrEqualTo: rhs.anchor!, multiplier: rhs.multiplier, constant: rhs.constant), withPriority: rhs.priority)
     }
 }
 
 extension NSLayoutYAxisAnchor {
-    @discardableResult public func matchLess(_ rhs: NSLayoutYAxisAnchor) -> NSLayoutConstraint {
-        return finalize(constraint: self.constraint(lessThanOrEqualTo: rhs))
+    @discardableResult public func matchOrLess(_ rhs: NSLayoutYAxisAnchor) -> NSLayoutConstraint {
+        return Anchorage.finalize(constraint: self.constraint(lessThanOrEqualTo: rhs))
     }
 
-    @discardableResult public func matchLess(_ rhs: LayoutExpression<NSLayoutYAxisAnchor, CGFloat>) -> NSLayoutConstraint {
-        return finalize(constraint: self.constraint(lessThanOrEqualTo: rhs.anchor!, multiplier: rhs.multiplier, constant: rhs.constant), withPriority: rhs.priority)
+    @discardableResult public func matchOrLess(_ rhs: LayoutExpression<NSLayoutYAxisAnchor, CGFloat>) -> NSLayoutConstraint {
+        return Anchorage.finalize(constraint: self.constraint(lessThanOrEqualTo: rhs.anchor!, multiplier: rhs.multiplier, constant: rhs.constant), withPriority: rhs.priority)
     }
 }
 
 extension EdgeAnchors {
-    @discardableResult public func matchLess(_ rhs: EdgeAnchors) -> ConstraintGroup {
+    @discardableResult public func matchOrLess(_ rhs: EdgeAnchors) -> ConstraintGroup {
         return self.finalize(constraintsLessThanOrEqualToEdges: rhs)
     }
 
-    @discardableResult public func matchLess(_ rhs: LayoutExpression<EdgeAnchors, CGFloat>) -> ConstraintGroup {
+    @discardableResult public func matchOrLess(_ rhs: LayoutExpression<EdgeAnchors, CGFloat>) -> ConstraintGroup {
         return self.finalize(constraintsLessThanOrEqualToEdges: rhs.anchor, constant: rhs.constant, priority: rhs.priority)
     }
 
-    @discardableResult public func matchLess(_ rhs: LayoutExpression<EdgeAnchors, EdgeInsets>) -> ConstraintGroup {
+    @discardableResult public func matchOrLess(_ rhs: LayoutExpression<EdgeAnchors, EdgeInsets>) -> ConstraintGroup {
         return self.finalize(constraintsLessThanOrEqualToEdges: rhs.anchor, insets: rhs.constant, priority: rhs.priority)
     }
 }
 
 extension AnchorPair {
-    @discardableResult public func matchLess(_ rhs: AnchorPair<T, U>) -> ConstraintPair {
+    @discardableResult public func matchOrLess(_ rhs: AnchorPair<T, U>) -> ConstraintPair {
         return self.finalize(constraintsLessThanOrEqualToEdges: rhs)
     }
 
-    @discardableResult public func matchLess(_ rhs: LayoutExpression<AnchorPair<T, U>, CGFloat>) -> ConstraintPair {
+    @discardableResult public func matchOrLess(_ rhs: LayoutExpression<AnchorPair<T, U>, CGFloat>) -> ConstraintPair {
         return self.finalize(constraintsLessThanOrEqualToEdges: rhs.anchor, constant: rhs.constant, priority: rhs.priority)
     }
+}
 
-    @discardableResult public func matchLess(_ rhs: CGSize) -> ConstraintPair
-        where T: NSLayoutDimension, U: NSLayoutDimension {
+extension AnchorPair where T: NSLayoutDimension, U: NSLayoutDimension {
+    @discardableResult public func matchOrLess(_ rhs: CGSize) -> ConstraintPair {
         return self.finalize(constraintsLessThanOrEqualToConstant: rhs)
     }
 
-    @discardableResult public func matchLess(_ rhs: LayoutExpression<AnchorPair<NSLayoutDimension, NSLayoutDimension>, CGSize>) -> ConstraintPair
-        where T: NSLayoutDimension, U: NSLayoutDimension {
+    @discardableResult public func matchOrLess(_ rhs: LayoutExpression<AnchorPair<NSLayoutDimension, NSLayoutDimension>, CGSize>) -> ConstraintPair {
         return self.finalize(constraintsLessThanOrEqualToConstant: rhs.constant, priority: rhs.priority)
     }
 }
+
 // Greater than
 extension NSLayoutDimension {
-    @discardableResult public func matchGreater<T: BinaryFloatingPoint>(_ rhs: T) -> NSLayoutConstraint {
-        return finalize(constraint: self.constraint(greaterThanOrEqualToConstant: CGFloat(rhs)))
+    @discardableResult public func matchOrMore<T: BinaryFloatingPoint>(_ rhs: T) -> NSLayoutConstraint {
+        return Anchorage.finalize(constraint: self.constraint(greaterThanOrEqualToConstant: CGFloat(rhs)))
     }
 
-    @discardableResult public func matchGreater(_ rhs: NSLayoutDimension) -> NSLayoutConstraint {
-        return finalize(constraint: self.constraint(greaterThanOrEqualTo: rhs))
+    @discardableResult public func matchOrMore(_ rhs: NSLayoutDimension) -> NSLayoutConstraint {
+        return Anchorage.finalize(constraint: self.constraint(greaterThanOrEqualTo: rhs))
     }
 
-    @discardableResult public func matchGreater(_ rhs: LayoutExpression<NSLayoutDimension, CGFloat>) -> NSLayoutConstraint {
+    @discardableResult public func matchOrMore(_ rhs: LayoutExpression<NSLayoutDimension, CGFloat>) -> NSLayoutConstraint {
         if let anchor = rhs.anchor {
-            return finalize(constraint: self.constraint(greaterThanOrEqualTo: anchor, multiplier: rhs.multiplier, constant: rhs.constant), withPriority: rhs.priority)
+            return Anchorage.finalize(constraint: self.constraint(greaterThanOrEqualTo: anchor, multiplier: rhs.multiplier, constant: rhs.constant), withPriority: rhs.priority)
         }
         else {
-            return finalize(constraint: self.constraint(greaterThanOrEqualToConstant: rhs.constant), withPriority: rhs.priority)
+            return Anchorage.finalize(constraint: self.constraint(greaterThanOrEqualToConstant: rhs.constant), withPriority: rhs.priority)
         }
     }
 }
 
 extension NSLayoutXAxisAnchor {
-    @discardableResult public func matchGreater(_ rhs: NSLayoutXAxisAnchor) -> NSLayoutConstraint {
-        return finalize(constraint: self.constraint(greaterThanOrEqualTo: rhs))
+    @discardableResult public func matchOrMore(_ rhs: NSLayoutXAxisAnchor) -> NSLayoutConstraint {
+        return Anchorage.finalize(constraint: self.constraint(greaterThanOrEqualTo: rhs))
     }
 
-    @discardableResult public func matchGreater(_ rhs: LayoutExpression<NSLayoutXAxisAnchor, CGFloat>) -> NSLayoutConstraint {
-        return finalize(constraint: self.constraint(greaterThanOrEqualTo: rhs.anchor!, multiplier: rhs.multiplier, constant: rhs.constant), withPriority: rhs.priority)
+    @discardableResult public func matchOrMore(_ rhs: LayoutExpression<NSLayoutXAxisAnchor, CGFloat>) -> NSLayoutConstraint {
+        return Anchorage.finalize(constraint: self.constraint(greaterThanOrEqualTo: rhs.anchor!, multiplier: rhs.multiplier, constant: rhs.constant), withPriority: rhs.priority)
     }
 }
 
 extension NSLayoutYAxisAnchor {
-    @discardableResult public func matchGreater(_ rhs: NSLayoutYAxisAnchor) -> NSLayoutConstraint {
-        return finalize(constraint: self.constraint(greaterThanOrEqualTo: rhs))
+    @discardableResult public func matchOrMore(_ rhs: NSLayoutYAxisAnchor) -> NSLayoutConstraint {
+        return Anchorage.finalize(constraint: self.constraint(greaterThanOrEqualTo: rhs))
     }
 
-    @discardableResult public func >= (_ rhs: LayoutExpression<NSLayoutYAxisAnchor, CGFloat>) -> NSLayoutConstraint {
-        return finalize(constraint: self.constraint(greaterThanOrEqualTo: rhs.anchor!, multiplier: rhs.multiplier, constant: rhs.constant), withPriority: rhs.priority)
+    @discardableResult public func matchOrMore(_ rhs: LayoutExpression<NSLayoutYAxisAnchor, CGFloat>) -> NSLayoutConstraint {
+        return Anchorage.finalize(constraint: self.constraint(greaterThanOrEqualTo: rhs.anchor!, multiplier: rhs.multiplier, constant: rhs.constant), withPriority: rhs.priority)
     }
 }
 
+extension EdgeAnchors {
+    @discardableResult public func matchOrMore(_ rhs: EdgeAnchors) -> ConstraintGroup {
+        return self.finalize(constraintsGreaterThanOrEqualToEdges: rhs)
+    }
 
-//
-//@discardableResult public func >= (lhs: EdgeAnchors, rhs: EdgeAnchors) -> ConstraintGroup {
-//    return lhs.finalize(constraintsGreaterThanOrEqualToEdges: rhs)
-//}
-//
-//@discardableResult public func >= (lhs: EdgeAnchors, rhs: LayoutExpression<EdgeAnchors, CGFloat>) -> ConstraintGroup {
-//    return lhs.finalize(constraintsGreaterThanOrEqualToEdges: rhs.anchor, constant: rhs.constant, priority: rhs.priority)
-//}
-//
-//@discardableResult public func >= (lhs: EdgeAnchors, rhs: LayoutExpression<EdgeAnchors, EdgeInsets>) -> ConstraintGroup {
-//    return lhs.finalize(constraintsGreaterThanOrEqualToEdges: rhs.anchor, insets: rhs.constant, priority: rhs.priority)
-//}
-//
-//@discardableResult public func >= <T, U>(lhs: AnchorPair<T, U>, rhs: AnchorPair<T, U>) -> ConstraintPair {
-//    return lhs.finalize(constraintsGreaterThanOrEqualToEdges: rhs)
-//}
-//
-//@discardableResult public func >= <T, U>(lhs: AnchorPair<T, U>, rhs: LayoutExpression<AnchorPair<T, U>, CGFloat>) -> ConstraintPair {
-//    return lhs.finalize(constraintsGreaterThanOrEqualToEdges: rhs.anchor, constant: rhs.constant, priority: rhs.priority)
-//}
-//
-//@discardableResult public func >= (lhs: AnchorPair<NSLayoutDimension, NSLayoutDimension>, rhs: CGSize) -> ConstraintPair {
-//    return lhs.finalize(constraintsGreaterThanOrEqualToConstant: rhs)
-//}
-//
-//@discardableResult public func >= (lhs: AnchorPair<NSLayoutDimension, NSLayoutDimension>, rhs: LayoutExpression<AnchorPair<NSLayoutDimension, NSLayoutDimension>, CGSize>) -> ConstraintPair {
-//    return lhs.finalize(constraintsGreaterThanOrEqualToConstant: rhs.constant, priority: rhs.priority)
-//}
-//
+    @discardableResult public func matchOrMore(_ rhs: LayoutExpression<EdgeAnchors, CGFloat>) -> ConstraintGroup {
+        return self.finalize(constraintsGreaterThanOrEqualToEdges: rhs.anchor, constant: rhs.constant, priority: rhs.priority)
+    }
+
+    @discardableResult public func matchOrMore(_ rhs: LayoutExpression<EdgeAnchors, EdgeInsets>) -> ConstraintGroup {
+        return self.finalize(constraintsGreaterThanOrEqualToEdges: rhs.anchor, insets: rhs.constant, priority: rhs.priority)
+    }
+}
+
+extension AnchorPair {
+    @discardableResult public func matchOrMore(_ rhs: AnchorPair<T, U>) -> ConstraintPair {
+        return self.finalize(constraintsGreaterThanOrEqualToEdges: rhs)
+    }
+
+    @discardableResult public func matchOrMore(_ rhs: LayoutExpression<AnchorPair<T, U>, CGFloat>) -> ConstraintPair {
+        return self.finalize(constraintsGreaterThanOrEqualToEdges: rhs.anchor, constant: rhs.constant, priority: rhs.priority)
+    }
+}
+
+extension AnchorPair where T: NSLayoutDimension, U: NSLayoutDimension {
+    @discardableResult public func matchOrMore(_ rhs: CGSize) -> ConstraintPair {
+        return self.finalize(constraintsGreaterThanOrEqualToConstant: rhs)
+    }
+
+    @discardableResult public func matchOrMore(_ rhs: LayoutExpression<AnchorPair<NSLayoutDimension, NSLayoutDimension>, CGSize>) -> ConstraintPair {
+        return self.finalize(constraintsGreaterThanOrEqualToConstant: rhs.constant, priority: rhs.priority)
+    }
+}
+
 //// MARK: - Priority
 //
 //precedencegroup PriorityPrecedence {


### PR DESCRIPTION
Resolving `==` types seems to really slow down build times on large projects. One idea is to provide an alternate set of anchorage functions that can replace `==`, `<=`, `>=`, etc. So instead of `viewA.topAnchor == viewB.topAnchor` you would say `viewA.topAnchor.pin(viewB.topAnchor)` or something like that. I think there is still added value from Anchorage implementation, but maybe we should also consider a lighter-weight constraint helper to use with the newer/better Apple APIs (just adding `edgeAnchors` type conveniences, for example).

AnchorageFast.swift extends all the anchoragable classes. Not able to see a build time difference in the demo app, but it is a pretty small code base. Not sure about the `match()` naming. Also considered `pin()` or `set()` or some other variant of `equals()`. Would love to come up with an ideal set of names that are more clear in function, but relatively brief.

Still need to:
- [ ] Support other operators (`~` or `+`, etc.)
- [ ] Replicate tests for new function
- [ ] Old functions should call new functions for single implementations
- [ ] Formally test build performance change
- [ ] Finalize function naming scheme