### PR TITLE
Add custom operators as alternatives to overloaded operators

### DIFF
--- a/Anchorage.podspec
+++ b/Anchorage.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "Anchorage"
-  s.version          = "4.4.0"
+  s.version          = "4.5.0"
   s.summary          = "A collection of operators and utilities that simplify iOS layout code."
   s.description      = <<-DESC
                        Create constraints using intuitive operators built directly on top of the NSLayoutAnchor API. Layout has never been simpler!

--- a/AnchorageTests/AnchorageTests.swift
+++ b/AnchorageTests/AnchorageTests.swift
@@ -75,7 +75,7 @@ class AnchorageTests: XCTestCase {
     }
 
     func testBasicEquality() {
-        let constraint = view1.widthAnchor |==| view2.widthAnchor
+        let constraint = view1.widthAnchor /==/ view2.widthAnchor
         assertIdentical(constraint.firstItem, view1)
         assertIdentical(constraint.secondItem, view2)
         XCTAssertEqual(constraint.constant, 0, accuracy: cgEpsilon)
@@ -88,7 +88,7 @@ class AnchorageTests: XCTestCase {
     }
 
     func testBasicLessThan() {
-        let constraint = view1.widthAnchor |<=| view2.widthAnchor
+        let constraint = view1.widthAnchor /<=/ view2.widthAnchor
         assertIdentical(constraint.firstItem, view1)
         assertIdentical(constraint.secondItem, view2)
         XCTAssertEqual(constraint.constant, 0, accuracy: cgEpsilon)
@@ -101,7 +101,7 @@ class AnchorageTests: XCTestCase {
     }
 
     func testBasicGreaterThan() {
-        let constraint = view1.widthAnchor |>=| view2.widthAnchor
+        let constraint = view1.widthAnchor />=/ view2.widthAnchor
         assertIdentical(constraint.firstItem, view1)
         assertIdentical(constraint.secondItem, view2)
         XCTAssertEqual(constraint.constant, 0, accuracy: cgEpsilon)
@@ -114,7 +114,7 @@ class AnchorageTests: XCTestCase {
     }
 
     func testEqualityWithOffset() {
-        let constraint = view1.widthAnchor |==| view2.widthAnchor + 10
+        let constraint = view1.widthAnchor /==/ view2.widthAnchor + 10
         assertIdentical(constraint.firstItem, view1)
         assertIdentical(constraint.secondItem, view2)
         XCTAssertEqual(constraint.constant, 10, accuracy: cgEpsilon)
@@ -127,7 +127,7 @@ class AnchorageTests: XCTestCase {
     }
 
     func testEqualityWithMultiplier() {
-        let constraint = view1.widthAnchor |==| view2.widthAnchor / 2
+        let constraint = view1.widthAnchor /==/ view2.widthAnchor / 2
         assertIdentical(constraint.firstItem, view1)
         assertIdentical(constraint.secondItem, view2)
         XCTAssertEqual(constraint.constant, 0, accuracy: cgEpsilon)
@@ -140,7 +140,7 @@ class AnchorageTests: XCTestCase {
     }
 
     func testAxisAnchorEqualityWithMultiplier() {
-        let constraint = view1.leadingAnchor |==| view2.trailingAnchor / 2
+        let constraint = view1.leadingAnchor /==/ view2.trailingAnchor / 2
         assertIdentical(constraint.firstItem, view1)
         assertIdentical(constraint.secondItem, view2)
         XCTAssertEqual(constraint.constant, 0, accuracy: cgEpsilon)
@@ -153,7 +153,7 @@ class AnchorageTests: XCTestCase {
     }
 
     func testEqualityWithOffsetAndMultiplier() {
-        let constraint = view1.widthAnchor |==| (view2.widthAnchor + 10) / 2
+        let constraint = view1.widthAnchor /==/ (view2.widthAnchor + 10) / 2
         assertIdentical(constraint.firstItem, view1)
         assertIdentical(constraint.secondItem, view2)
         XCTAssertEqual(constraint.constant, 10, accuracy: cgEpsilon)
@@ -166,7 +166,7 @@ class AnchorageTests: XCTestCase {
     }
 
     func testAxisAnchorEqualityWithOffsetAndMultiplier() {
-        let constraint = view1.trailingAnchor |==| (view2.centerXAnchor + 10) / 2
+        let constraint = view1.trailingAnchor /==/ (view2.centerXAnchor + 10) / 2
         assertIdentical(constraint.firstItem, view1)
         assertIdentical(constraint.secondItem, view2)
         XCTAssertEqual(constraint.constant, 10, accuracy: cgEpsilon)
@@ -179,7 +179,7 @@ class AnchorageTests: XCTestCase {
     }
 
     func testEqualityWithPriorityConstant() {
-        let constraint = view1.widthAnchor |==| view2.widthAnchor ~ .high
+        let constraint = view1.widthAnchor /==/ view2.widthAnchor ~ .high
         assertIdentical(constraint.firstItem, view1)
         assertIdentical(constraint.secondItem, view2)
         XCTAssertEqual(constraint.constant, 0, accuracy: cgEpsilon)
@@ -192,7 +192,7 @@ class AnchorageTests: XCTestCase {
     }
 
     func testEqualityWithPriorityLiteral() {
-        let constraint = view1.widthAnchor |==| view2.widthAnchor ~ 750
+        let constraint = view1.widthAnchor /==/ view2.widthAnchor ~ 750
         assertIdentical(constraint.firstItem, view1)
         assertIdentical(constraint.secondItem, view2)
         XCTAssertEqual(constraint.constant, 0, accuracy: cgEpsilon)
@@ -205,7 +205,7 @@ class AnchorageTests: XCTestCase {
     }
 
     func testEqualityWithPriorityConstantMath() {
-        let constraint = view1.widthAnchor |==| view2.widthAnchor ~ .high - 1
+        let constraint = view1.widthAnchor /==/ view2.widthAnchor ~ .high - 1
         assertIdentical(constraint.firstItem, view1)
         assertIdentical(constraint.secondItem, view2)
         XCTAssertEqual(constraint.constant, 0, accuracy: cgEpsilon)
@@ -218,7 +218,7 @@ class AnchorageTests: XCTestCase {
     }
 
     func testEqualityWithPriorityLiteralMath() {
-        let constraint = view1.widthAnchor |==| view2.widthAnchor ~ Priority(750 - 1)
+        let constraint = view1.widthAnchor /==/ view2.widthAnchor ~ Priority(750 - 1)
         assertIdentical(constraint.firstItem, view1)
         assertIdentical(constraint.secondItem, view2)
         XCTAssertEqual(constraint.constant, 0, accuracy: cgEpsilon)
@@ -231,7 +231,7 @@ class AnchorageTests: XCTestCase {
     }
 
     func testEqualityWithOffsetAndPriorityMath() {
-        let constraint = view1.widthAnchor |==| view2.widthAnchor + 10 ~ .high - 1
+        let constraint = view1.widthAnchor /==/ view2.widthAnchor + 10 ~ .high - 1
         assertIdentical(constraint.firstItem, view1)
         assertIdentical(constraint.secondItem, view2)
         XCTAssertEqual(constraint.constant, 10, accuracy: cgEpsilon)
@@ -244,7 +244,7 @@ class AnchorageTests: XCTestCase {
     }
 
     func testEqualityWithOffsetAndMultiplierAndPriorityMath() {
-        let constraint = view1.widthAnchor |==| (view2.widthAnchor + 10) / 2 ~ .high - 1
+        let constraint = view1.widthAnchor /==/ (view2.widthAnchor + 10) / 2 ~ .high - 1
         assertIdentical(constraint.firstItem, view1)
         assertIdentical(constraint.secondItem, view2)
         XCTAssertEqual(constraint.constant, 10, accuracy: cgEpsilon)
@@ -257,7 +257,7 @@ class AnchorageTests: XCTestCase {
     }
 
     func testCenterAnchors() {
-        let constraints = view1.centerAnchors |==| view2.centerAnchors
+        let constraints = view1.centerAnchors /==/ view2.centerAnchors
 
         let horizontal = constraints.first
         assertIdentical(horizontal.firstItem, view1)
@@ -283,7 +283,7 @@ class AnchorageTests: XCTestCase {
     }
 
     func testCenterAnchorsWithOffsetAndPriority() {
-        let constraints = view1.centerAnchors |==| view2.centerAnchors + 10 ~ .high - 1
+        let constraints = view1.centerAnchors /==/ view2.centerAnchors + 10 ~ .high - 1
 
         let horizontal = constraints.first
         assertIdentical(horizontal.firstItem, view1)
@@ -309,7 +309,7 @@ class AnchorageTests: XCTestCase {
     }
 
     func testHorizontalAnchors() {
-        let constraints = view1.horizontalAnchors |==| view2.horizontalAnchors + 10 ~ .high - 1
+        let constraints = view1.horizontalAnchors /==/ view2.horizontalAnchors + 10 ~ .high - 1
 
         let leading = constraints.first
         assertIdentical(leading.firstItem, view1)
@@ -335,7 +335,7 @@ class AnchorageTests: XCTestCase {
     }
 
     func testVerticalAnchors() {
-        let constraints = view1.verticalAnchors |==| view2.verticalAnchors + 10 ~ .high - 1
+        let constraints = view1.verticalAnchors /==/ view2.verticalAnchors + 10 ~ .high - 1
 
         let top = constraints.first
         assertIdentical(top.firstItem, view1)
@@ -361,7 +361,7 @@ class AnchorageTests: XCTestCase {
     }
 
     func testSizeAnchors() {
-        let constraints = view1.sizeAnchors |==| view2.sizeAnchors + 10 ~ .high - 1
+        let constraints = view1.sizeAnchors /==/ view2.sizeAnchors + 10 ~ .high - 1
 
         let width = constraints.first
         assertIdentical(width.firstItem, view1)
@@ -387,7 +387,7 @@ class AnchorageTests: XCTestCase {
     }
 
     func testSizeAnchorsWithConstants() {
-        let constraints = view1.sizeAnchors |==| CGSize(width: 50, height: 100) ~ .high - 1
+        let constraints = view1.sizeAnchors /==/ CGSize(width: 50, height: 100) ~ .high - 1
 
         let width = constraints.first
         assertIdentical(width.firstItem, view1)
@@ -413,7 +413,7 @@ class AnchorageTests: XCTestCase {
     }
 
     func testEdgeAnchors() {
-        let constraints = view1.edgeAnchors |==| view2.edgeAnchors + 10 ~ .high - 1
+        let constraints = view1.edgeAnchors /==/ view2.edgeAnchors + 10 ~ .high - 1
 
         let all = constraints.all
         XCTAssertEqual(all.count, 4)
@@ -480,7 +480,7 @@ class AnchorageTests: XCTestCase {
     func testEdgeAnchorsWithInsets() {
         let insets = EdgeInsets(top: 10, left: 5, bottom: 15, right: 20)
 
-        let constraints = view1.edgeAnchors |==| view2.edgeAnchors + insets ~ .high - 1
+        let constraints = view1.edgeAnchors /==/ view2.edgeAnchors + insets ~ .high - 1
 
         let leading = constraints.leading
         assertIdentical(leading.firstItem, view1)
@@ -529,8 +529,8 @@ class AnchorageTests: XCTestCase {
 
     func testInactiveBatchConstraints() {
         let constraints = Anchorage.batch(active: false) {
-            view1.widthAnchor |==| view2.widthAnchor
-            view1.heightAnchor |==| view2.heightAnchor / 2 ~ .low
+            view1.widthAnchor /==/ view2.widthAnchor
+            view1.heightAnchor /==/ view2.heightAnchor / 2 ~ .low
         }
 
         let width = constraints[0]
@@ -559,8 +559,8 @@ class AnchorageTests: XCTestCase {
 
     func testActiveBatchConstraints() {
         let constraints = Anchorage.batch {
-            view1.widthAnchor |==| view2.widthAnchor
-            view1.heightAnchor |==| view2.heightAnchor / 2 ~ .low
+            view1.widthAnchor /==/ view2.widthAnchor
+            view1.heightAnchor /==/ view2.heightAnchor / 2 ~ .low
         }
 
         let width = constraints[0]
@@ -590,11 +590,11 @@ class AnchorageTests: XCTestCase {
     func testNestedBatchConstraints() {
         var nestedConstraints: [NSLayoutConstraint] = []
         let constraints = Anchorage.batch {
-            view1.widthAnchor |==| view2.widthAnchor
+            view1.widthAnchor /==/ view2.widthAnchor
             nestedConstraints = Anchorage.batch(active: false) {
-                view1.heightAnchor |==| view2.heightAnchor / 2 ~ .low
+                view1.heightAnchor /==/ view2.heightAnchor / 2 ~ .low
             }
-            view1.leadingAnchor |==| view2.leadingAnchor
+            view1.leadingAnchor /==/ view2.leadingAnchor
         }
         
         let width = constraints[0]

--- a/AnchorageTests/AnchorageTests.swift
+++ b/AnchorageTests/AnchorageTests.swift
@@ -74,6 +74,11 @@ class AnchorageTests: XCTestCase {
 #endif
     }
 
+    override func tearDown() {
+        view1.removeFromSuperview()
+        view2.removeFromSuperview()
+    }
+
 }
 
 // MARK: - Overloaded operators

--- a/AnchorageTests/AnchorageTests.swift
+++ b/AnchorageTests/AnchorageTests.swift
@@ -1205,6 +1205,77 @@ extension AnchorageTests {
     }
 }
 
+// MARK: - Performance Tests
+
+extension AnchorageTests {
+
+    private func runRepeatedEdgeConstraintAssignments(numTests: Int = 10000, assignment: () -> ConstraintGroup) {
+        var constraintGroup: ConstraintGroup?
+        for _ in 0 ..< numTests {
+            if let constraintGroup = constraintGroup {
+                NSLayoutConstraint.deactivate(constraintGroup.all)
+            }
+            constraintGroup = assignment()
+        }
+    }
+
+    // MARK: Equal To
+
+    func testOperatorOverloadPerformance_EqualTo() {
+        measure {
+            runRepeatedEdgeConstraintAssignments { () -> ConstraintGroup in
+                return view1.edgeAnchors == view2.edgeAnchors
+            }
+        }
+    }
+
+    func testCustomOperatorPerformance_EqualTo() {
+        measure {
+            runRepeatedEdgeConstraintAssignments { () -> ConstraintGroup in
+                return view1.edgeAnchors /==/ view2.edgeAnchors
+            }
+        }
+    }
+
+    // MARK: Less Than or Equal To
+
+    func testOperatorOverloadPerformance_LessThanOrEqualTo() {
+        measure {
+            runRepeatedEdgeConstraintAssignments { () -> ConstraintGroup in
+                return view1.edgeAnchors <= view2.edgeAnchors
+            }
+        }
+    }
+
+    func testCustomOperatorPerformance_LessThanOrEqualTo() {
+        measure {
+            runRepeatedEdgeConstraintAssignments { () -> ConstraintGroup in
+                return view1.edgeAnchors /<=/ view2.edgeAnchors
+            }
+        }
+    }
+
+    // MARK: Greater Than or Equal To
+
+    func testOperatorOverloadPerformance_GreaterThanOrEqualTo() {
+        measure {
+            runRepeatedEdgeConstraintAssignments { () -> ConstraintGroup in
+                return view1.edgeAnchors >= view2.edgeAnchors
+            }
+        }
+    }
+
+    func testCustomOperatorPerformance_GreaterThanOrEqualTo() {
+        measure {
+            runRepeatedEdgeConstraintAssignments { () -> ConstraintGroup in
+                return view1.edgeAnchors />=/ view2.edgeAnchors
+            }
+        }
+    }
+}
+
+// MARK: - Utility Functions and Extensions
+
 extension AnchorageTests {
 
     func assertIdentical(_ expression1: @autoclosure () -> AnyObject?, _ expression2: @autoclosure () -> AnyObject?, _ message: @autoclosure () -> String = "Objects were not identical", file: StaticString = #file, line: UInt = #line) {

--- a/AnchorageTests/AnchorageTests.swift
+++ b/AnchorageTests/AnchorageTests.swift
@@ -75,7 +75,7 @@ class AnchorageTests: XCTestCase {
     }
 
     func testBasicEquality() {
-        let constraint = view1.widthAnchor /==/ view2.widthAnchor
+        let constraint = view1.widthAnchor == view2.widthAnchor
         assertIdentical(constraint.firstItem, view1)
         assertIdentical(constraint.secondItem, view2)
         XCTAssertEqual(constraint.constant, 0, accuracy: cgEpsilon)
@@ -88,7 +88,7 @@ class AnchorageTests: XCTestCase {
     }
 
     func testBasicLessThan() {
-        let constraint = view1.widthAnchor /<=/ view2.widthAnchor
+        let constraint = view1.widthAnchor <= view2.widthAnchor
         assertIdentical(constraint.firstItem, view1)
         assertIdentical(constraint.secondItem, view2)
         XCTAssertEqual(constraint.constant, 0, accuracy: cgEpsilon)
@@ -101,7 +101,7 @@ class AnchorageTests: XCTestCase {
     }
 
     func testBasicGreaterThan() {
-        let constraint = view1.widthAnchor />=/ view2.widthAnchor
+        let constraint = view1.widthAnchor >= view2.widthAnchor
         assertIdentical(constraint.firstItem, view1)
         assertIdentical(constraint.secondItem, view2)
         XCTAssertEqual(constraint.constant, 0, accuracy: cgEpsilon)
@@ -114,7 +114,7 @@ class AnchorageTests: XCTestCase {
     }
 
     func testEqualityWithOffset() {
-        let constraint = view1.widthAnchor /==/ view2.widthAnchor + 10
+        let constraint = view1.widthAnchor == view2.widthAnchor + 10
         assertIdentical(constraint.firstItem, view1)
         assertIdentical(constraint.secondItem, view2)
         XCTAssertEqual(constraint.constant, 10, accuracy: cgEpsilon)
@@ -127,7 +127,7 @@ class AnchorageTests: XCTestCase {
     }
 
     func testEqualityWithMultiplier() {
-        let constraint = view1.widthAnchor /==/ view2.widthAnchor / 2
+        let constraint = view1.widthAnchor == view2.widthAnchor / 2
         assertIdentical(constraint.firstItem, view1)
         assertIdentical(constraint.secondItem, view2)
         XCTAssertEqual(constraint.constant, 0, accuracy: cgEpsilon)
@@ -140,7 +140,7 @@ class AnchorageTests: XCTestCase {
     }
 
     func testAxisAnchorEqualityWithMultiplier() {
-        let constraint = view1.leadingAnchor /==/ view2.trailingAnchor / 2
+        let constraint = view1.leadingAnchor == view2.trailingAnchor / 2
         assertIdentical(constraint.firstItem, view1)
         assertIdentical(constraint.secondItem, view2)
         XCTAssertEqual(constraint.constant, 0, accuracy: cgEpsilon)
@@ -153,7 +153,7 @@ class AnchorageTests: XCTestCase {
     }
 
     func testEqualityWithOffsetAndMultiplier() {
-        let constraint = view1.widthAnchor /==/ (view2.widthAnchor + 10) / 2
+        let constraint = view1.widthAnchor == (view2.widthAnchor + 10) / 2
         assertIdentical(constraint.firstItem, view1)
         assertIdentical(constraint.secondItem, view2)
         XCTAssertEqual(constraint.constant, 10, accuracy: cgEpsilon)
@@ -166,7 +166,7 @@ class AnchorageTests: XCTestCase {
     }
 
     func testAxisAnchorEqualityWithOffsetAndMultiplier() {
-        let constraint = view1.trailingAnchor /==/ (view2.centerXAnchor + 10) / 2
+        let constraint = view1.trailingAnchor == (view2.centerXAnchor + 10) / 2
         assertIdentical(constraint.firstItem, view1)
         assertIdentical(constraint.secondItem, view2)
         XCTAssertEqual(constraint.constant, 10, accuracy: cgEpsilon)
@@ -179,7 +179,7 @@ class AnchorageTests: XCTestCase {
     }
 
     func testEqualityWithPriorityConstant() {
-        let constraint = view1.widthAnchor /==/ view2.widthAnchor ~ .high
+        let constraint = view1.widthAnchor == view2.widthAnchor ~ .high
         assertIdentical(constraint.firstItem, view1)
         assertIdentical(constraint.secondItem, view2)
         XCTAssertEqual(constraint.constant, 0, accuracy: cgEpsilon)
@@ -192,7 +192,7 @@ class AnchorageTests: XCTestCase {
     }
 
     func testEqualityWithPriorityLiteral() {
-        let constraint = view1.widthAnchor /==/ view2.widthAnchor ~ 750
+        let constraint = view1.widthAnchor == view2.widthAnchor ~ 750
         assertIdentical(constraint.firstItem, view1)
         assertIdentical(constraint.secondItem, view2)
         XCTAssertEqual(constraint.constant, 0, accuracy: cgEpsilon)
@@ -205,7 +205,7 @@ class AnchorageTests: XCTestCase {
     }
 
     func testEqualityWithPriorityConstantMath() {
-        let constraint = view1.widthAnchor /==/ view2.widthAnchor ~ .high - 1
+        let constraint = view1.widthAnchor == view2.widthAnchor ~ .high - 1
         assertIdentical(constraint.firstItem, view1)
         assertIdentical(constraint.secondItem, view2)
         XCTAssertEqual(constraint.constant, 0, accuracy: cgEpsilon)
@@ -218,7 +218,7 @@ class AnchorageTests: XCTestCase {
     }
 
     func testEqualityWithPriorityLiteralMath() {
-        let constraint = view1.widthAnchor /==/ view2.widthAnchor ~ Priority(750 - 1)
+        let constraint = view1.widthAnchor == view2.widthAnchor ~ Priority(750 - 1)
         assertIdentical(constraint.firstItem, view1)
         assertIdentical(constraint.secondItem, view2)
         XCTAssertEqual(constraint.constant, 0, accuracy: cgEpsilon)
@@ -231,7 +231,7 @@ class AnchorageTests: XCTestCase {
     }
 
     func testEqualityWithOffsetAndPriorityMath() {
-        let constraint = view1.widthAnchor /==/ view2.widthAnchor + 10 ~ .high - 1
+        let constraint = view1.widthAnchor == view2.widthAnchor + 10 ~ .high - 1
         assertIdentical(constraint.firstItem, view1)
         assertIdentical(constraint.secondItem, view2)
         XCTAssertEqual(constraint.constant, 10, accuracy: cgEpsilon)
@@ -244,7 +244,7 @@ class AnchorageTests: XCTestCase {
     }
 
     func testEqualityWithOffsetAndMultiplierAndPriorityMath() {
-        let constraint = view1.widthAnchor /==/ (view2.widthAnchor + 10) / 2 ~ .high - 1
+        let constraint = view1.widthAnchor == (view2.widthAnchor + 10) / 2 ~ .high - 1
         assertIdentical(constraint.firstItem, view1)
         assertIdentical(constraint.secondItem, view2)
         XCTAssertEqual(constraint.constant, 10, accuracy: cgEpsilon)
@@ -257,7 +257,7 @@ class AnchorageTests: XCTestCase {
     }
 
     func testCenterAnchors() {
-        let constraints = view1.centerAnchors /==/ view2.centerAnchors
+        let constraints = view1.centerAnchors == view2.centerAnchors
 
         let horizontal = constraints.first
         assertIdentical(horizontal.firstItem, view1)
@@ -283,7 +283,7 @@ class AnchorageTests: XCTestCase {
     }
 
     func testCenterAnchorsWithOffsetAndPriority() {
-        let constraints = view1.centerAnchors /==/ view2.centerAnchors + 10 ~ .high - 1
+        let constraints = view1.centerAnchors == view2.centerAnchors + 10 ~ .high - 1
 
         let horizontal = constraints.first
         assertIdentical(horizontal.firstItem, view1)
@@ -309,7 +309,7 @@ class AnchorageTests: XCTestCase {
     }
 
     func testHorizontalAnchors() {
-        let constraints = view1.horizontalAnchors /==/ view2.horizontalAnchors + 10 ~ .high - 1
+        let constraints = view1.horizontalAnchors == view2.horizontalAnchors + 10 ~ .high - 1
 
         let leading = constraints.first
         assertIdentical(leading.firstItem, view1)
@@ -335,7 +335,7 @@ class AnchorageTests: XCTestCase {
     }
 
     func testVerticalAnchors() {
-        let constraints = view1.verticalAnchors /==/ view2.verticalAnchors + 10 ~ .high - 1
+        let constraints = view1.verticalAnchors == view2.verticalAnchors + 10 ~ .high - 1
 
         let top = constraints.first
         assertIdentical(top.firstItem, view1)
@@ -361,7 +361,7 @@ class AnchorageTests: XCTestCase {
     }
 
     func testSizeAnchors() {
-        let constraints = view1.sizeAnchors /==/ view2.sizeAnchors + 10 ~ .high - 1
+        let constraints = view1.sizeAnchors == view2.sizeAnchors + 10 ~ .high - 1
 
         let width = constraints.first
         assertIdentical(width.firstItem, view1)
@@ -387,7 +387,7 @@ class AnchorageTests: XCTestCase {
     }
 
     func testSizeAnchorsWithConstants() {
-        let constraints = view1.sizeAnchors /==/ CGSize(width: 50, height: 100) ~ .high - 1
+        let constraints = view1.sizeAnchors == CGSize(width: 50, height: 100) ~ .high - 1
 
         let width = constraints.first
         assertIdentical(width.firstItem, view1)
@@ -413,7 +413,7 @@ class AnchorageTests: XCTestCase {
     }
 
     func testEdgeAnchors() {
-        let constraints = view1.edgeAnchors /==/ view2.edgeAnchors + 10 ~ .high - 1
+        let constraints = view1.edgeAnchors == view2.edgeAnchors + 10 ~ .high - 1
 
         let all = constraints.all
         XCTAssertEqual(all.count, 4)
@@ -480,7 +480,7 @@ class AnchorageTests: XCTestCase {
     func testEdgeAnchorsWithInsets() {
         let insets = EdgeInsets(top: 10, left: 5, bottom: 15, right: 20)
 
-        let constraints = view1.edgeAnchors /==/ view2.edgeAnchors + insets ~ .high - 1
+        let constraints = view1.edgeAnchors == view2.edgeAnchors + insets ~ .high - 1
 
         let leading = constraints.leading
         assertIdentical(leading.firstItem, view1)
@@ -529,8 +529,8 @@ class AnchorageTests: XCTestCase {
 
     func testInactiveBatchConstraints() {
         let constraints = Anchorage.batch(active: false) {
-            view1.widthAnchor /==/ view2.widthAnchor
-            view1.heightAnchor /==/ view2.heightAnchor / 2 ~ .low
+            view1.widthAnchor == view2.widthAnchor
+            view1.heightAnchor == view2.heightAnchor / 2 ~ .low
         }
 
         let width = constraints[0]
@@ -559,8 +559,8 @@ class AnchorageTests: XCTestCase {
 
     func testActiveBatchConstraints() {
         let constraints = Anchorage.batch {
-            view1.widthAnchor /==/ view2.widthAnchor
-            view1.heightAnchor /==/ view2.heightAnchor / 2 ~ .low
+            view1.widthAnchor == view2.widthAnchor
+            view1.heightAnchor == view2.heightAnchor / 2 ~ .low
         }
 
         let width = constraints[0]
@@ -590,11 +590,11 @@ class AnchorageTests: XCTestCase {
     func testNestedBatchConstraints() {
         var nestedConstraints: [NSLayoutConstraint] = []
         let constraints = Anchorage.batch {
-            view1.widthAnchor /==/ view2.widthAnchor
+            view1.widthAnchor == view2.widthAnchor
             nestedConstraints = Anchorage.batch(active: false) {
-                view1.heightAnchor /==/ view2.heightAnchor / 2 ~ .low
+                view1.heightAnchor == view2.heightAnchor / 2 ~ .low
             }
-            view1.leadingAnchor /==/ view2.leadingAnchor
+            view1.leadingAnchor == view2.leadingAnchor
         }
         
         let width = constraints[0]

--- a/AnchorageTests/AnchorageTests.swift
+++ b/AnchorageTests/AnchorageTests.swift
@@ -74,6 +74,12 @@ class AnchorageTests: XCTestCase {
 #endif
     }
 
+}
+
+// MARK: - Overloaded operators
+
+extension AnchorageTests {
+
     func testBasicEquality() {
         let constraint = view1.widthAnchor == view2.widthAnchor
         assertIdentical(constraint.firstItem, view1)
@@ -586,7 +592,7 @@ class AnchorageTests: XCTestCase {
         XCTAssertEqual(height.firstAttribute, .height)
         XCTAssertEqual(height.secondAttribute, .height)
     }
-    
+
     func testNestedBatchConstraints() {
         var nestedConstraints: [NSLayoutConstraint] = []
         let constraints = Anchorage.batch {
@@ -596,11 +602,11 @@ class AnchorageTests: XCTestCase {
             }
             view1.leadingAnchor == view2.leadingAnchor
         }
-        
+
         let width = constraints[0]
         let leading = constraints[1]
         let height = nestedConstraints[0]
-        
+
         assertIdentical(width.firstItem, view1)
         assertIdentical(width.secondItem, view2)
         XCTAssertEqual(width.constant, 0, accuracy: cgEpsilon)
@@ -610,7 +616,7 @@ class AnchorageTests: XCTestCase {
         XCTAssertEqual(width.relation, .equal)
         XCTAssertEqual(width.firstAttribute, .width)
         XCTAssertEqual(width.secondAttribute, .width)
-        
+
         assertIdentical(height.firstItem, view1)
         assertIdentical(height.secondItem, view2)
         XCTAssertEqual(height.constant, 0, accuracy: cgEpsilon)
@@ -620,7 +626,7 @@ class AnchorageTests: XCTestCase {
         XCTAssertEqual(height.relation, .equal)
         XCTAssertEqual(height.firstAttribute, .height)
         XCTAssertEqual(height.secondAttribute, .height)
-        
+
         assertIdentical(leading.firstItem, view1)
         assertIdentical(leading.secondItem, view2)
         XCTAssertEqual(leading.constant, 0, accuracy: cgEpsilon)
@@ -632,6 +638,571 @@ class AnchorageTests: XCTestCase {
         XCTAssertEqual(leading.secondAttribute, .leading)
     }
 
+}
+
+
+
+// MARK: - Custom operators
+
+extension AnchorageTests {
+
+    func testBasicEquality_WithCustomOperators() {
+        let constraint = view1.widthAnchor /==/ view2.widthAnchor
+        assertIdentical(constraint.firstItem, view1)
+        assertIdentical(constraint.secondItem, view2)
+        XCTAssertEqual(constraint.constant, 0, accuracy: cgEpsilon)
+        XCTAssertEqual(constraint.multiplier, 1, accuracy: cgEpsilon)
+        XCTAssertEqual(constraint.priority.rawValue, TestPriorityRequired.rawValue, accuracy: fEpsilon)
+        XCTAssertTrue(constraint.isActive)
+        XCTAssertEqual(constraint.relation, .equal)
+        XCTAssertEqual(constraint.firstAttribute, .width)
+        XCTAssertEqual(constraint.secondAttribute, .width)
+    }
+
+    func testBasicLessThan_WithCustomOperators() {
+        let constraint = view1.widthAnchor /<=/ view2.widthAnchor
+        assertIdentical(constraint.firstItem, view1)
+        assertIdentical(constraint.secondItem, view2)
+        XCTAssertEqual(constraint.constant, 0, accuracy: cgEpsilon)
+        XCTAssertEqual(constraint.multiplier, 1, accuracy: cgEpsilon)
+        XCTAssertEqual(constraint.priority.rawValue, TestPriorityRequired.rawValue, accuracy: fEpsilon)
+        XCTAssertTrue(constraint.isActive)
+        XCTAssertEqual(constraint.relation, .lessThanOrEqual)
+        XCTAssertEqual(constraint.firstAttribute, .width)
+        XCTAssertEqual(constraint.secondAttribute, .width)
+    }
+
+    func testBasicGreaterThan_WithCustomOperators() {
+        let constraint = view1.widthAnchor />=/ view2.widthAnchor
+        assertIdentical(constraint.firstItem, view1)
+        assertIdentical(constraint.secondItem, view2)
+        XCTAssertEqual(constraint.constant, 0, accuracy: cgEpsilon)
+        XCTAssertEqual(constraint.multiplier, 1, accuracy: cgEpsilon)
+        XCTAssertEqual(constraint.priority.rawValue, TestPriorityRequired.rawValue, accuracy: fEpsilon)
+        XCTAssertTrue(constraint.isActive)
+        XCTAssertEqual(constraint.relation, .greaterThanOrEqual)
+        XCTAssertEqual(constraint.firstAttribute, .width)
+        XCTAssertEqual(constraint.secondAttribute, .width)
+    }
+
+    func testEqualityWithOffset_WithCustomOperators() {
+        let constraint = view1.widthAnchor /==/ view2.widthAnchor + 10
+        assertIdentical(constraint.firstItem, view1)
+        assertIdentical(constraint.secondItem, view2)
+        XCTAssertEqual(constraint.constant, 10, accuracy: cgEpsilon)
+        XCTAssertEqual(constraint.multiplier, 1, accuracy: cgEpsilon)
+        XCTAssertEqual(constraint.priority.rawValue, TestPriorityRequired.rawValue, accuracy: fEpsilon)
+        XCTAssertTrue(constraint.isActive)
+        XCTAssertEqual(constraint.relation, .equal)
+        XCTAssertEqual(constraint.firstAttribute, .width)
+        XCTAssertEqual(constraint.secondAttribute, .width)
+    }
+
+    func testEqualityWithMultiplier_WithCustomOperators() {
+        let constraint = view1.widthAnchor /==/ view2.widthAnchor / 2
+        assertIdentical(constraint.firstItem, view1)
+        assertIdentical(constraint.secondItem, view2)
+        XCTAssertEqual(constraint.constant, 0, accuracy: cgEpsilon)
+        XCTAssertEqual(constraint.multiplier, 0.5, accuracy: cgEpsilon)
+        XCTAssertEqual(constraint.priority.rawValue, TestPriorityRequired.rawValue, accuracy: fEpsilon)
+        XCTAssertTrue(constraint.isActive)
+        XCTAssertEqual(constraint.relation, .equal)
+        XCTAssertEqual(constraint.firstAttribute, .width)
+        XCTAssertEqual(constraint.secondAttribute, .width)
+    }
+
+    func testAxisAnchorEqualityWithMultiplier_WithCustomOperators() {
+        let constraint = view1.leadingAnchor /==/ view2.trailingAnchor / 2
+        assertIdentical(constraint.firstItem, view1)
+        assertIdentical(constraint.secondItem, view2)
+        XCTAssertEqual(constraint.constant, 0, accuracy: cgEpsilon)
+        XCTAssertEqual(constraint.multiplier, 0.5, accuracy: cgEpsilon)
+        XCTAssertEqual(constraint.priority.rawValue, TestPriorityRequired.rawValue, accuracy: fEpsilon)
+        XCTAssertTrue(constraint.isActive)
+        XCTAssertEqual(constraint.relation, .equal)
+        XCTAssertEqual(constraint.firstAttribute, .leading)
+        XCTAssertEqual(constraint.secondAttribute, .trailing)
+    }
+
+    func testEqualityWithOffsetAndMultiplier_WithCustomOperators() {
+        let constraint = view1.widthAnchor /==/ (view2.widthAnchor + 10) / 2
+        assertIdentical(constraint.firstItem, view1)
+        assertIdentical(constraint.secondItem, view2)
+        XCTAssertEqual(constraint.constant, 10, accuracy: cgEpsilon)
+        XCTAssertEqual(constraint.multiplier, 0.5, accuracy: cgEpsilon)
+        XCTAssertEqual(constraint.priority.rawValue, TestPriorityRequired.rawValue, accuracy: fEpsilon)
+        XCTAssertTrue(constraint.isActive)
+        XCTAssertEqual(constraint.relation, .equal)
+        XCTAssertEqual(constraint.firstAttribute, .width)
+        XCTAssertEqual(constraint.secondAttribute, .width)
+    }
+
+    func testAxisAnchorEqualityWithOffsetAndMultiplier_WithCustomOperators() {
+        let constraint = view1.trailingAnchor /==/ (view2.centerXAnchor + 10) / 2
+        assertIdentical(constraint.firstItem, view1)
+        assertIdentical(constraint.secondItem, view2)
+        XCTAssertEqual(constraint.constant, 10, accuracy: cgEpsilon)
+        XCTAssertEqual(constraint.multiplier, 0.5, accuracy: cgEpsilon)
+        XCTAssertEqual(constraint.priority.rawValue, TestPriorityRequired.rawValue, accuracy: fEpsilon)
+        XCTAssertTrue(constraint.isActive)
+        XCTAssertEqual(constraint.relation, .equal)
+        XCTAssertEqual(constraint.firstAttribute, .trailing)
+        XCTAssertEqual(constraint.secondAttribute, .centerX)
+    }
+
+    func testEqualityWithPriorityConstant_WithCustomOperators() {
+        let constraint = view1.widthAnchor /==/ view2.widthAnchor ~ .high
+        assertIdentical(constraint.firstItem, view1)
+        assertIdentical(constraint.secondItem, view2)
+        XCTAssertEqual(constraint.constant, 0, accuracy: cgEpsilon)
+        XCTAssertEqual(constraint.multiplier, 1, accuracy: cgEpsilon)
+        XCTAssertEqual(constraint.priority.rawValue, TestPriorityHigh.rawValue, accuracy: fEpsilon)
+        XCTAssertTrue(constraint.isActive)
+        XCTAssertEqual(constraint.relation, .equal)
+        XCTAssertEqual(constraint.firstAttribute, .width)
+        XCTAssertEqual(constraint.secondAttribute, .width)
+    }
+
+    func testEqualityWithPriorityLiteral_WithCustomOperators() {
+        let constraint = view1.widthAnchor /==/ view2.widthAnchor ~ 750
+        assertIdentical(constraint.firstItem, view1)
+        assertIdentical(constraint.secondItem, view2)
+        XCTAssertEqual(constraint.constant, 0, accuracy: cgEpsilon)
+        XCTAssertEqual(constraint.multiplier, 1, accuracy: cgEpsilon)
+        XCTAssertEqual(constraint.priority.rawValue, TestPriorityHigh.rawValue, accuracy: fEpsilon)
+        XCTAssertTrue(constraint.isActive)
+        XCTAssertEqual(constraint.relation, .equal)
+        XCTAssertEqual(constraint.firstAttribute, .width)
+        XCTAssertEqual(constraint.secondAttribute, .width)
+    }
+
+    func testEqualityWithPriorityConstantMath_WithCustomOperators() {
+        let constraint = view1.widthAnchor /==/ view2.widthAnchor ~ .high - 1
+        assertIdentical(constraint.firstItem, view1)
+        assertIdentical(constraint.secondItem, view2)
+        XCTAssertEqual(constraint.constant, 0, accuracy: cgEpsilon)
+        XCTAssertEqual(constraint.multiplier, 1, accuracy: cgEpsilon)
+        XCTAssertEqual(constraint.priority.rawValue, TestPriorityHigh.rawValue - 1, accuracy: fEpsilon)
+        XCTAssertTrue(constraint.isActive)
+        XCTAssertEqual(constraint.relation, .equal)
+        XCTAssertEqual(constraint.firstAttribute, .width)
+        XCTAssertEqual(constraint.secondAttribute, .width)
+    }
+
+    func testEqualityWithPriorityLiteralMath_WithCustomOperators() {
+        let constraint = view1.widthAnchor /==/ view2.widthAnchor ~ Priority(750 - 1)
+        assertIdentical(constraint.firstItem, view1)
+        assertIdentical(constraint.secondItem, view2)
+        XCTAssertEqual(constraint.constant, 0, accuracy: cgEpsilon)
+        XCTAssertEqual(constraint.multiplier, 1, accuracy: cgEpsilon)
+        XCTAssertEqual(constraint.priority.rawValue, TestPriorityHigh.rawValue - 1, accuracy: fEpsilon)
+        XCTAssertTrue(constraint.isActive)
+        XCTAssertEqual(constraint.relation, .equal)
+        XCTAssertEqual(constraint.firstAttribute, .width)
+        XCTAssertEqual(constraint.secondAttribute, .width)
+    }
+
+    func testEqualityWithOffsetAndPriorityMath_WithCustomOperators() {
+        let constraint = view1.widthAnchor /==/ view2.widthAnchor + 10 ~ .high - 1
+        assertIdentical(constraint.firstItem, view1)
+        assertIdentical(constraint.secondItem, view2)
+        XCTAssertEqual(constraint.constant, 10, accuracy: cgEpsilon)
+        XCTAssertEqual(constraint.multiplier, 1, accuracy: cgEpsilon)
+        XCTAssertEqual(constraint.priority.rawValue, TestPriorityHigh.rawValue - 1, accuracy: fEpsilon)
+        XCTAssertTrue(constraint.isActive)
+        XCTAssertEqual(constraint.relation, .equal)
+        XCTAssertEqual(constraint.firstAttribute, .width)
+        XCTAssertEqual(constraint.secondAttribute, .width)
+    }
+
+    func testEqualityWithOffsetAndMultiplierAndPriorityMath_WithCustomOperators() {
+        let constraint = view1.widthAnchor /==/ (view2.widthAnchor + 10) / 2 ~ .high - 1
+        assertIdentical(constraint.firstItem, view1)
+        assertIdentical(constraint.secondItem, view2)
+        XCTAssertEqual(constraint.constant, 10, accuracy: cgEpsilon)
+        XCTAssertEqual(constraint.multiplier, 0.5, accuracy: cgEpsilon)
+        XCTAssertEqual(constraint.priority.rawValue, TestPriorityHigh.rawValue - 1, accuracy: fEpsilon)
+        XCTAssertTrue(constraint.isActive)
+        XCTAssertEqual(constraint.relation, .equal)
+        XCTAssertEqual(constraint.firstAttribute, .width)
+        XCTAssertEqual(constraint.secondAttribute, .width)
+    }
+
+    func testCenterAnchors_WithCustomOperators() {
+        let constraints = view1.centerAnchors /==/ view2.centerAnchors
+
+        let horizontal = constraints.first
+        assertIdentical(horizontal.firstItem, view1)
+        assertIdentical(horizontal.secondItem, view2)
+        XCTAssertEqual(horizontal.constant, 0, accuracy: cgEpsilon)
+        XCTAssertEqual(horizontal.multiplier, 1, accuracy: cgEpsilon)
+        XCTAssertEqual(horizontal.priority.rawValue, TestPriorityRequired.rawValue, accuracy: fEpsilon)
+        XCTAssertTrue(horizontal.isActive)
+        XCTAssertEqual(horizontal.relation, .equal)
+        XCTAssertEqual(horizontal.firstAttribute, .centerX)
+        XCTAssertEqual(horizontal.secondAttribute, .centerX)
+
+        let vertical = constraints.second
+        assertIdentical(vertical.firstItem, view1)
+        assertIdentical(vertical.secondItem, view2)
+        XCTAssertEqual(vertical.constant, 0, accuracy: cgEpsilon)
+        XCTAssertEqual(vertical.multiplier, 1, accuracy: cgEpsilon)
+        XCTAssertEqual(vertical.priority.rawValue, TestPriorityRequired.rawValue, accuracy: fEpsilon)
+        XCTAssertTrue(vertical.isActive)
+        XCTAssertEqual(vertical.relation, .equal)
+        XCTAssertEqual(vertical.firstAttribute, .centerY)
+        XCTAssertEqual(vertical.secondAttribute, .centerY)
+    }
+
+    func testCenterAnchorsWithOffsetAndPriority_WithCustomOperators() {
+        let constraints = view1.centerAnchors /==/ view2.centerAnchors + 10 ~ .high - 1
+
+        let horizontal = constraints.first
+        assertIdentical(horizontal.firstItem, view1)
+        assertIdentical(horizontal.secondItem, view2)
+        XCTAssertEqual(horizontal.constant, 10, accuracy: cgEpsilon)
+        XCTAssertEqual(horizontal.multiplier, 1, accuracy: cgEpsilon)
+        XCTAssertEqual(horizontal.priority.rawValue, TestPriorityHigh.rawValue - 1, accuracy: fEpsilon)
+        XCTAssertTrue(horizontal.isActive)
+        XCTAssertEqual(horizontal.relation, .equal)
+        XCTAssertEqual(horizontal.firstAttribute, .centerX)
+        XCTAssertEqual(horizontal.secondAttribute, .centerX)
+
+        let vertical = constraints.second
+        assertIdentical(vertical.firstItem, view1)
+        assertIdentical(vertical.secondItem, view2)
+        XCTAssertEqual(vertical.constant, 10, accuracy: cgEpsilon)
+        XCTAssertEqual(vertical.multiplier, 1, accuracy: cgEpsilon)
+        XCTAssertEqual(vertical.priority.rawValue, TestPriorityHigh.rawValue - 1, accuracy: fEpsilon)
+        XCTAssertTrue(vertical.isActive)
+        XCTAssertEqual(vertical.relation, .equal)
+        XCTAssertEqual(vertical.firstAttribute, .centerY)
+        XCTAssertEqual(vertical.secondAttribute, .centerY)
+    }
+
+    func testHorizontalAnchors_WithCustomOperators() {
+        let constraints = view1.horizontalAnchors /==/ view2.horizontalAnchors + 10 ~ .high - 1
+
+        let leading = constraints.first
+        assertIdentical(leading.firstItem, view1)
+        assertIdentical(leading.secondItem, view2)
+        XCTAssertEqual(leading.constant, 10, accuracy: cgEpsilon)
+        XCTAssertEqual(leading.multiplier, 1, accuracy: cgEpsilon)
+        XCTAssertEqual(leading.priority.rawValue, TestPriorityHigh.rawValue - 1, accuracy: fEpsilon)
+        XCTAssertTrue(leading.isActive)
+        XCTAssertEqual(leading.relation, .equal)
+        XCTAssertEqual(leading.firstAttribute, .leading)
+        XCTAssertEqual(leading.secondAttribute, .leading)
+
+        let trailing = constraints.second
+        assertIdentical(trailing.firstItem, view1)
+        assertIdentical(trailing.secondItem, view2)
+        XCTAssertEqual(trailing.constant, -10, accuracy: cgEpsilon)
+        XCTAssertEqual(trailing.multiplier, 1, accuracy: cgEpsilon)
+        XCTAssertEqual(trailing.priority.rawValue, TestPriorityHigh.rawValue - 1, accuracy: fEpsilon)
+        XCTAssertTrue(trailing.isActive)
+        XCTAssertEqual(trailing.relation, .equal)
+        XCTAssertEqual(trailing.firstAttribute, .trailing)
+        XCTAssertEqual(trailing.secondAttribute, .trailing)
+    }
+
+    func testVerticalAnchors_WithCustomOperators() {
+        let constraints = view1.verticalAnchors /==/ view2.verticalAnchors + 10 ~ .high - 1
+
+        let top = constraints.first
+        assertIdentical(top.firstItem, view1)
+        assertIdentical(top.secondItem, view2)
+        XCTAssertEqual(top.constant, 10, accuracy: cgEpsilon)
+        XCTAssertEqual(top.multiplier, 1, accuracy: cgEpsilon)
+        XCTAssertEqual(top.priority.rawValue, TestPriorityHigh.rawValue - 1, accuracy: fEpsilon)
+        XCTAssertTrue(top.isActive)
+        XCTAssertEqual(top.relation, .equal)
+        XCTAssertEqual(top.firstAttribute, .top)
+        XCTAssertEqual(top.secondAttribute, .top)
+
+        let bottom = constraints.second
+        assertIdentical(bottom.firstItem, view1)
+        assertIdentical(bottom.secondItem, view2)
+        XCTAssertEqual(bottom.constant, -10, accuracy: cgEpsilon)
+        XCTAssertEqual(bottom.multiplier, 1, accuracy: cgEpsilon)
+        XCTAssertEqual(bottom.priority.rawValue, TestPriorityHigh.rawValue - 1, accuracy: fEpsilon)
+        XCTAssertTrue(bottom.isActive)
+        XCTAssertEqual(bottom.relation, .equal)
+        XCTAssertEqual(bottom.firstAttribute, .bottom)
+        XCTAssertEqual(bottom.secondAttribute, .bottom)
+    }
+
+    func testSizeAnchors_WithCustomOperators() {
+        let constraints = view1.sizeAnchors /==/ view2.sizeAnchors + 10 ~ .high - 1
+
+        let width = constraints.first
+        assertIdentical(width.firstItem, view1)
+        assertIdentical(width.secondItem, view2)
+        XCTAssertEqual(width.constant, 10, accuracy: cgEpsilon)
+        XCTAssertEqual(width.multiplier, 1, accuracy: cgEpsilon)
+        XCTAssertEqual(width.priority.rawValue, TestPriorityHigh.rawValue - 1, accuracy: fEpsilon)
+        XCTAssertTrue(width.isActive)
+        XCTAssertEqual(width.relation, .equal)
+        XCTAssertEqual(width.firstAttribute, .width)
+        XCTAssertEqual(width.secondAttribute, .width)
+
+        let height = constraints.second
+        assertIdentical(height.firstItem, view1)
+        assertIdentical(height.secondItem, view2)
+        XCTAssertEqual(height.constant, 10, accuracy: cgEpsilon)
+        XCTAssertEqual(height.multiplier, 1, accuracy: cgEpsilon)
+        XCTAssertEqual(height.priority.rawValue, TestPriorityHigh.rawValue - 1, accuracy: fEpsilon)
+        XCTAssertTrue(height.isActive)
+        XCTAssertEqual(height.relation, .equal)
+        XCTAssertEqual(height.firstAttribute, .height)
+        XCTAssertEqual(height.secondAttribute, .height)
+    }
+
+    func testSizeAnchorsWithConstants_WithCustomOperators() {
+        let constraints = view1.sizeAnchors /==/ CGSize(width: 50, height: 100) ~ .high - 1
+
+        let width = constraints.first
+        assertIdentical(width.firstItem, view1)
+        assertIdentical(width.secondItem, nil)
+        XCTAssertEqual(width.constant, 50, accuracy: cgEpsilon)
+        XCTAssertEqual(width.multiplier, 1, accuracy: cgEpsilon)
+        XCTAssertEqual(width.priority.rawValue, TestPriorityHigh.rawValue - 1, accuracy: fEpsilon)
+        XCTAssertTrue(width.isActive)
+        XCTAssertEqual(width.relation, .equal)
+        XCTAssertEqual(width.firstAttribute, .width)
+        XCTAssertEqual(width.secondAttribute, .notAnAttribute)
+
+        let height = constraints.second
+        assertIdentical(height.firstItem, view1)
+        assertIdentical(height.secondItem, nil)
+        XCTAssertEqual(height.constant, 100, accuracy: cgEpsilon)
+        XCTAssertEqual(height.multiplier, 1, accuracy: cgEpsilon)
+        XCTAssertEqual(height.priority.rawValue, TestPriorityHigh.rawValue - 1, accuracy: fEpsilon)
+        XCTAssertTrue(height.isActive)
+        XCTAssertEqual(height.relation, .equal)
+        XCTAssertEqual(height.firstAttribute, .height)
+        XCTAssertEqual(height.secondAttribute, .notAnAttribute)
+    }
+
+    func testEdgeAnchors_WithCustomOperators() {
+        let constraints = view1.edgeAnchors /==/ view2.edgeAnchors + 10 ~ .high - 1
+
+        let all = constraints.all
+        XCTAssertEqual(all.count, 4)
+        XCTAssertEqual(all[0].firstAttribute, .top)
+        XCTAssertEqual(all[1].firstAttribute, .leading)
+        XCTAssertEqual(all[2].firstAttribute, .bottom)
+        XCTAssertEqual(all[3].firstAttribute, .trailing)
+
+        let vertical = constraints.vertical
+        XCTAssertEqual(vertical.count, 2)
+        XCTAssertEqual(vertical[0].firstAttribute, .top)
+        XCTAssertEqual(vertical[1].firstAttribute, .bottom)
+
+        let horizontal = constraints.horizontal
+        XCTAssertEqual(horizontal.count, 2)
+        XCTAssertEqual(horizontal[0].firstAttribute, .leading)
+        XCTAssertEqual(horizontal[1].firstAttribute, .trailing)
+
+        let leading = constraints.leading
+        assertIdentical(leading.firstItem, view1)
+        assertIdentical(leading.secondItem, view2)
+        XCTAssertEqual(leading.constant, 10, accuracy: cgEpsilon)
+        XCTAssertEqual(leading.multiplier, 1, accuracy: cgEpsilon)
+        XCTAssertEqual(leading.priority.rawValue, TestPriorityHigh.rawValue - 1, accuracy: fEpsilon)
+        XCTAssertTrue(leading.isActive)
+        XCTAssertEqual(leading.relation, .equal)
+        XCTAssertEqual(leading.firstAttribute, .leading)
+        XCTAssertEqual(leading.secondAttribute, .leading)
+
+        let trailing = constraints.trailing
+        assertIdentical(trailing.firstItem, view1)
+        assertIdentical(trailing.secondItem, view2)
+        XCTAssertEqual(trailing.constant, -10, accuracy: cgEpsilon)
+        XCTAssertEqual(trailing.multiplier, 1, accuracy: cgEpsilon)
+        XCTAssertEqual(trailing.priority.rawValue, TestPriorityHigh.rawValue - 1, accuracy: fEpsilon)
+        XCTAssertTrue(trailing.isActive)
+        XCTAssertEqual(trailing.relation, .equal)
+        XCTAssertEqual(trailing.firstAttribute, .trailing)
+        XCTAssertEqual(trailing.secondAttribute, .trailing)
+
+        let top = constraints.top
+        assertIdentical(top.firstItem, view1)
+        assertIdentical(top.secondItem, view2)
+        XCTAssertEqual(top.constant, 10, accuracy: cgEpsilon)
+        XCTAssertEqual(top.multiplier, 1, accuracy: cgEpsilon)
+        XCTAssertEqual(top.priority.rawValue, TestPriorityHigh.rawValue - 1, accuracy: fEpsilon)
+        XCTAssertTrue(top.isActive)
+        XCTAssertEqual(top.relation, .equal)
+        XCTAssertEqual(top.firstAttribute, .top)
+        XCTAssertEqual(top.secondAttribute, .top)
+
+        let bottom = constraints.bottom
+        assertIdentical(bottom.firstItem, view1)
+        assertIdentical(bottom.secondItem, view2)
+        XCTAssertEqual(bottom.constant, -10, accuracy: cgEpsilon)
+        XCTAssertEqual(bottom.multiplier, 1, accuracy: cgEpsilon)
+        XCTAssertEqual(bottom.priority.rawValue, TestPriorityHigh.rawValue - 1, accuracy: fEpsilon)
+        XCTAssertTrue(bottom.isActive)
+        XCTAssertEqual(bottom.relation, .equal)
+        XCTAssertEqual(bottom.firstAttribute, .bottom)
+        XCTAssertEqual(bottom.secondAttribute, .bottom)
+    }
+
+    func testEdgeAnchorsWithInsets_WithCustomOperators() {
+        let insets = EdgeInsets(top: 10, left: 5, bottom: 15, right: 20)
+
+        let constraints = view1.edgeAnchors /==/ view2.edgeAnchors + insets ~ .high - 1
+
+        let leading = constraints.leading
+        assertIdentical(leading.firstItem, view1)
+        assertIdentical(leading.secondItem, view2)
+        XCTAssertEqual(leading.constant, 5, accuracy: cgEpsilon)
+        XCTAssertEqual(leading.multiplier, 1, accuracy: cgEpsilon)
+        XCTAssertEqual(leading.priority.rawValue, TestPriorityHigh.rawValue - 1, accuracy: fEpsilon)
+        XCTAssertTrue(leading.isActive)
+        XCTAssertEqual(leading.relation, .equal)
+        XCTAssertEqual(leading.firstAttribute, .leading)
+        XCTAssertEqual(leading.secondAttribute, .leading)
+
+        let trailing = constraints.trailing
+        assertIdentical(trailing.firstItem, view1)
+        assertIdentical(trailing.secondItem, view2)
+        XCTAssertEqual(trailing.constant, -20, accuracy: cgEpsilon)
+        XCTAssertEqual(trailing.multiplier, 1, accuracy: cgEpsilon)
+        XCTAssertEqual(trailing.priority.rawValue, TestPriorityHigh.rawValue - 1, accuracy: fEpsilon)
+        XCTAssertTrue(trailing.isActive)
+        XCTAssertEqual(trailing.relation, .equal)
+        XCTAssertEqual(trailing.firstAttribute, .trailing)
+        XCTAssertEqual(trailing.secondAttribute, .trailing)
+
+        let top = constraints.top
+        assertIdentical(top.firstItem, view1)
+        assertIdentical(top.secondItem, view2)
+        XCTAssertEqual(top.constant, 10, accuracy: cgEpsilon)
+        XCTAssertEqual(top.multiplier, 1, accuracy: cgEpsilon)
+        XCTAssertEqual(top.priority.rawValue, TestPriorityHigh.rawValue - 1, accuracy: fEpsilon)
+        XCTAssertTrue(top.isActive)
+        XCTAssertEqual(top.relation, .equal)
+        XCTAssertEqual(top.firstAttribute, .top)
+        XCTAssertEqual(top.secondAttribute, .top)
+
+        let bottom = constraints.bottom
+        assertIdentical(bottom.firstItem, view1)
+        assertIdentical(bottom.secondItem, view2)
+        XCTAssertEqual(bottom.constant, -15, accuracy: cgEpsilon)
+        XCTAssertEqual(bottom.multiplier, 1, accuracy: cgEpsilon)
+        XCTAssertEqual(bottom.priority.rawValue, TestPriorityHigh.rawValue - 1, accuracy: fEpsilon)
+        XCTAssertTrue(bottom.isActive)
+        XCTAssertEqual(bottom.relation, .equal)
+        XCTAssertEqual(bottom.firstAttribute, .bottom)
+        XCTAssertEqual(bottom.secondAttribute, .bottom)
+    }
+
+    func testInactiveBatchConstraints_WithCustomOperators() {
+        let constraints = Anchorage.batch(active: false) {
+            view1.widthAnchor /==/ view2.widthAnchor
+            view1.heightAnchor /==/ view2.heightAnchor / 2 ~ .low
+        }
+
+        let width = constraints[0]
+        let height = constraints[1]
+
+        assertIdentical(width.firstItem, view1)
+        assertIdentical(width.secondItem, view2)
+        XCTAssertEqual(width.constant, 0, accuracy: cgEpsilon)
+        XCTAssertEqual(width.multiplier, 1, accuracy: cgEpsilon)
+        XCTAssertEqual(width.priority.rawValue, TestPriorityRequired.rawValue, accuracy: fEpsilon)
+        XCTAssertFalse(width.isActive)
+        XCTAssertEqual(width.relation, .equal)
+        XCTAssertEqual(width.firstAttribute, .width)
+        XCTAssertEqual(width.secondAttribute, .width)
+
+        assertIdentical(height.firstItem, view1)
+        assertIdentical(height.secondItem, view2)
+        XCTAssertEqual(height.constant, 0, accuracy: cgEpsilon)
+        XCTAssertEqual(height.multiplier, 0.5, accuracy: cgEpsilon)
+        XCTAssertEqual(height.priority.rawValue, TestPriorityLow.rawValue, accuracy: fEpsilon)
+        XCTAssertFalse(height.isActive)
+        XCTAssertEqual(height.relation, .equal)
+        XCTAssertEqual(height.firstAttribute, .height)
+        XCTAssertEqual(height.secondAttribute, .height)
+    }
+
+    func testActiveBatchConstraints_WithCustomOperators() {
+        let constraints = Anchorage.batch {
+            view1.widthAnchor /==/ view2.widthAnchor
+            view1.heightAnchor /==/ view2.heightAnchor / 2 ~ .low
+        }
+
+        let width = constraints[0]
+        let height = constraints[1]
+
+        assertIdentical(width.firstItem, view1)
+        assertIdentical(width.secondItem, view2)
+        XCTAssertEqual(width.constant, 0, accuracy: cgEpsilon)
+        XCTAssertEqual(width.multiplier, 1, accuracy: cgEpsilon)
+        XCTAssertEqual(width.priority.rawValue, TestPriorityRequired.rawValue, accuracy: fEpsilon)
+        XCTAssertTrue(width.isActive)
+        XCTAssertEqual(width.relation, .equal)
+        XCTAssertEqual(width.firstAttribute, .width)
+        XCTAssertEqual(width.secondAttribute, .width)
+
+        assertIdentical(height.firstItem, view1)
+        assertIdentical(height.secondItem, view2)
+        XCTAssertEqual(height.constant, 0, accuracy: cgEpsilon)
+        XCTAssertEqual(height.multiplier, 0.5, accuracy: cgEpsilon)
+        XCTAssertEqual(height.priority.rawValue, TestPriorityLow.rawValue, accuracy: fEpsilon)
+        XCTAssertTrue(height.isActive)
+        XCTAssertEqual(height.relation, .equal)
+        XCTAssertEqual(height.firstAttribute, .height)
+        XCTAssertEqual(height.secondAttribute, .height)
+    }
+
+    func testNestedBatchConstraints_WithCustomOperators() {
+        var nestedConstraints: [NSLayoutConstraint] = []
+        let constraints = Anchorage.batch {
+            view1.widthAnchor /==/ view2.widthAnchor
+            nestedConstraints = Anchorage.batch(active: false) {
+                view1.heightAnchor /==/ view2.heightAnchor / 2 ~ .low
+            }
+            view1.leadingAnchor /==/ view2.leadingAnchor
+        }
+
+        let width = constraints[0]
+        let leading = constraints[1]
+        let height = nestedConstraints[0]
+
+        assertIdentical(width.firstItem, view1)
+        assertIdentical(width.secondItem, view2)
+        XCTAssertEqual(width.constant, 0, accuracy: cgEpsilon)
+        XCTAssertEqual(width.multiplier, 1, accuracy: cgEpsilon)
+        XCTAssertEqual(width.priority.rawValue, TestPriorityRequired.rawValue, accuracy: fEpsilon)
+        XCTAssertTrue(width.isActive)
+        XCTAssertEqual(width.relation, .equal)
+        XCTAssertEqual(width.firstAttribute, .width)
+        XCTAssertEqual(width.secondAttribute, .width)
+
+        assertIdentical(height.firstItem, view1)
+        assertIdentical(height.secondItem, view2)
+        XCTAssertEqual(height.constant, 0, accuracy: cgEpsilon)
+        XCTAssertEqual(height.multiplier, 0.5, accuracy: cgEpsilon)
+        XCTAssertEqual(height.priority.rawValue, TestPriorityLow.rawValue, accuracy: fEpsilon)
+        XCTAssertFalse(height.isActive)
+        XCTAssertEqual(height.relation, .equal)
+        XCTAssertEqual(height.firstAttribute, .height)
+        XCTAssertEqual(height.secondAttribute, .height)
+
+        assertIdentical(leading.firstItem, view1)
+        assertIdentical(leading.secondItem, view2)
+        XCTAssertEqual(leading.constant, 0, accuracy: cgEpsilon)
+        XCTAssertEqual(leading.multiplier, 1, accuracy: cgEpsilon)
+        XCTAssertEqual(leading.priority.rawValue, TestPriorityRequired.rawValue, accuracy: fEpsilon)
+        XCTAssertTrue(leading.isActive)
+        XCTAssertEqual(leading.relation, .equal)
+        XCTAssertEqual(leading.firstAttribute, .leading)
+        XCTAssertEqual(leading.secondAttribute, .leading)
+    }
 }
 
 extension AnchorageTests {

--- a/AnchorageTests/AnchorageTests.swift
+++ b/AnchorageTests/AnchorageTests.swift
@@ -75,7 +75,7 @@ class AnchorageTests: XCTestCase {
     }
 
     func testBasicEquality() {
-        let constraint = view1.widthAnchor == view2.widthAnchor
+        let constraint = view1.widthAnchor |==| view2.widthAnchor
         assertIdentical(constraint.firstItem, view1)
         assertIdentical(constraint.secondItem, view2)
         XCTAssertEqual(constraint.constant, 0, accuracy: cgEpsilon)
@@ -88,7 +88,7 @@ class AnchorageTests: XCTestCase {
     }
 
     func testBasicLessThan() {
-        let constraint = view1.widthAnchor <= view2.widthAnchor
+        let constraint = view1.widthAnchor |<=| view2.widthAnchor
         assertIdentical(constraint.firstItem, view1)
         assertIdentical(constraint.secondItem, view2)
         XCTAssertEqual(constraint.constant, 0, accuracy: cgEpsilon)
@@ -101,7 +101,7 @@ class AnchorageTests: XCTestCase {
     }
 
     func testBasicGreaterThan() {
-        let constraint = view1.widthAnchor >= view2.widthAnchor
+        let constraint = view1.widthAnchor |>=| view2.widthAnchor
         assertIdentical(constraint.firstItem, view1)
         assertIdentical(constraint.secondItem, view2)
         XCTAssertEqual(constraint.constant, 0, accuracy: cgEpsilon)
@@ -114,7 +114,7 @@ class AnchorageTests: XCTestCase {
     }
 
     func testEqualityWithOffset() {
-        let constraint = view1.widthAnchor == view2.widthAnchor + 10
+        let constraint = view1.widthAnchor |==| view2.widthAnchor + 10
         assertIdentical(constraint.firstItem, view1)
         assertIdentical(constraint.secondItem, view2)
         XCTAssertEqual(constraint.constant, 10, accuracy: cgEpsilon)
@@ -127,7 +127,7 @@ class AnchorageTests: XCTestCase {
     }
 
     func testEqualityWithMultiplier() {
-        let constraint = view1.widthAnchor == view2.widthAnchor / 2
+        let constraint = view1.widthAnchor |==| view2.widthAnchor / 2
         assertIdentical(constraint.firstItem, view1)
         assertIdentical(constraint.secondItem, view2)
         XCTAssertEqual(constraint.constant, 0, accuracy: cgEpsilon)
@@ -140,7 +140,7 @@ class AnchorageTests: XCTestCase {
     }
 
     func testAxisAnchorEqualityWithMultiplier() {
-        let constraint = view1.leadingAnchor == view2.trailingAnchor / 2
+        let constraint = view1.leadingAnchor |==| view2.trailingAnchor / 2
         assertIdentical(constraint.firstItem, view1)
         assertIdentical(constraint.secondItem, view2)
         XCTAssertEqual(constraint.constant, 0, accuracy: cgEpsilon)
@@ -153,7 +153,7 @@ class AnchorageTests: XCTestCase {
     }
 
     func testEqualityWithOffsetAndMultiplier() {
-        let constraint = view1.widthAnchor == (view2.widthAnchor + 10) / 2
+        let constraint = view1.widthAnchor |==| (view2.widthAnchor + 10) / 2
         assertIdentical(constraint.firstItem, view1)
         assertIdentical(constraint.secondItem, view2)
         XCTAssertEqual(constraint.constant, 10, accuracy: cgEpsilon)
@@ -166,7 +166,7 @@ class AnchorageTests: XCTestCase {
     }
 
     func testAxisAnchorEqualityWithOffsetAndMultiplier() {
-        let constraint = view1.trailingAnchor == (view2.centerXAnchor + 10) / 2
+        let constraint = view1.trailingAnchor |==| (view2.centerXAnchor + 10) / 2
         assertIdentical(constraint.firstItem, view1)
         assertIdentical(constraint.secondItem, view2)
         XCTAssertEqual(constraint.constant, 10, accuracy: cgEpsilon)
@@ -179,7 +179,7 @@ class AnchorageTests: XCTestCase {
     }
 
     func testEqualityWithPriorityConstant() {
-        let constraint = view1.widthAnchor == view2.widthAnchor ~ .high
+        let constraint = view1.widthAnchor |==| view2.widthAnchor ~ .high
         assertIdentical(constraint.firstItem, view1)
         assertIdentical(constraint.secondItem, view2)
         XCTAssertEqual(constraint.constant, 0, accuracy: cgEpsilon)
@@ -192,7 +192,7 @@ class AnchorageTests: XCTestCase {
     }
 
     func testEqualityWithPriorityLiteral() {
-        let constraint = view1.widthAnchor == view2.widthAnchor ~ 750
+        let constraint = view1.widthAnchor |==| view2.widthAnchor ~ 750
         assertIdentical(constraint.firstItem, view1)
         assertIdentical(constraint.secondItem, view2)
         XCTAssertEqual(constraint.constant, 0, accuracy: cgEpsilon)
@@ -205,7 +205,7 @@ class AnchorageTests: XCTestCase {
     }
 
     func testEqualityWithPriorityConstantMath() {
-        let constraint = view1.widthAnchor == view2.widthAnchor ~ .high - 1
+        let constraint = view1.widthAnchor |==| view2.widthAnchor ~ .high - 1
         assertIdentical(constraint.firstItem, view1)
         assertIdentical(constraint.secondItem, view2)
         XCTAssertEqual(constraint.constant, 0, accuracy: cgEpsilon)
@@ -218,7 +218,7 @@ class AnchorageTests: XCTestCase {
     }
 
     func testEqualityWithPriorityLiteralMath() {
-        let constraint = view1.widthAnchor == view2.widthAnchor ~ Priority(750 - 1)
+        let constraint = view1.widthAnchor |==| view2.widthAnchor ~ Priority(750 - 1)
         assertIdentical(constraint.firstItem, view1)
         assertIdentical(constraint.secondItem, view2)
         XCTAssertEqual(constraint.constant, 0, accuracy: cgEpsilon)
@@ -231,7 +231,7 @@ class AnchorageTests: XCTestCase {
     }
 
     func testEqualityWithOffsetAndPriorityMath() {
-        let constraint = view1.widthAnchor == view2.widthAnchor + 10 ~ .high - 1
+        let constraint = view1.widthAnchor |==| view2.widthAnchor + 10 ~ .high - 1
         assertIdentical(constraint.firstItem, view1)
         assertIdentical(constraint.secondItem, view2)
         XCTAssertEqual(constraint.constant, 10, accuracy: cgEpsilon)
@@ -244,7 +244,7 @@ class AnchorageTests: XCTestCase {
     }
 
     func testEqualityWithOffsetAndMultiplierAndPriorityMath() {
-        let constraint = view1.widthAnchor == (view2.widthAnchor + 10) / 2 ~ .high - 1
+        let constraint = view1.widthAnchor |==| (view2.widthAnchor + 10) / 2 ~ .high - 1
         assertIdentical(constraint.firstItem, view1)
         assertIdentical(constraint.secondItem, view2)
         XCTAssertEqual(constraint.constant, 10, accuracy: cgEpsilon)
@@ -257,7 +257,7 @@ class AnchorageTests: XCTestCase {
     }
 
     func testCenterAnchors() {
-        let constraints = view1.centerAnchors == view2.centerAnchors
+        let constraints = view1.centerAnchors |==| view2.centerAnchors
 
         let horizontal = constraints.first
         assertIdentical(horizontal.firstItem, view1)
@@ -283,7 +283,7 @@ class AnchorageTests: XCTestCase {
     }
 
     func testCenterAnchorsWithOffsetAndPriority() {
-        let constraints = view1.centerAnchors == view2.centerAnchors + 10 ~ .high - 1
+        let constraints = view1.centerAnchors |==| view2.centerAnchors + 10 ~ .high - 1
 
         let horizontal = constraints.first
         assertIdentical(horizontal.firstItem, view1)
@@ -309,7 +309,7 @@ class AnchorageTests: XCTestCase {
     }
 
     func testHorizontalAnchors() {
-        let constraints = view1.horizontalAnchors == view2.horizontalAnchors + 10 ~ .high - 1
+        let constraints = view1.horizontalAnchors |==| view2.horizontalAnchors + 10 ~ .high - 1
 
         let leading = constraints.first
         assertIdentical(leading.firstItem, view1)
@@ -335,7 +335,7 @@ class AnchorageTests: XCTestCase {
     }
 
     func testVerticalAnchors() {
-        let constraints = view1.verticalAnchors == view2.verticalAnchors + 10 ~ .high - 1
+        let constraints = view1.verticalAnchors |==| view2.verticalAnchors + 10 ~ .high - 1
 
         let top = constraints.first
         assertIdentical(top.firstItem, view1)
@@ -361,7 +361,7 @@ class AnchorageTests: XCTestCase {
     }
 
     func testSizeAnchors() {
-        let constraints = view1.sizeAnchors == view2.sizeAnchors + 10 ~ .high - 1
+        let constraints = view1.sizeAnchors |==| view2.sizeAnchors + 10 ~ .high - 1
 
         let width = constraints.first
         assertIdentical(width.firstItem, view1)
@@ -387,7 +387,7 @@ class AnchorageTests: XCTestCase {
     }
 
     func testSizeAnchorsWithConstants() {
-        let constraints = view1.sizeAnchors == CGSize(width: 50, height: 100) ~ .high - 1
+        let constraints = view1.sizeAnchors |==| CGSize(width: 50, height: 100) ~ .high - 1
 
         let width = constraints.first
         assertIdentical(width.firstItem, view1)
@@ -413,7 +413,7 @@ class AnchorageTests: XCTestCase {
     }
 
     func testEdgeAnchors() {
-        let constraints = view1.edgeAnchors == view2.edgeAnchors + 10 ~ .high - 1
+        let constraints = view1.edgeAnchors |==| view2.edgeAnchors + 10 ~ .high - 1
 
         let all = constraints.all
         XCTAssertEqual(all.count, 4)
@@ -480,7 +480,7 @@ class AnchorageTests: XCTestCase {
     func testEdgeAnchorsWithInsets() {
         let insets = EdgeInsets(top: 10, left: 5, bottom: 15, right: 20)
 
-        let constraints = view1.edgeAnchors == view2.edgeAnchors + insets ~ .high - 1
+        let constraints = view1.edgeAnchors |==| view2.edgeAnchors + insets ~ .high - 1
 
         let leading = constraints.leading
         assertIdentical(leading.firstItem, view1)
@@ -529,8 +529,8 @@ class AnchorageTests: XCTestCase {
 
     func testInactiveBatchConstraints() {
         let constraints = Anchorage.batch(active: false) {
-            view1.widthAnchor == view2.widthAnchor
-            view1.heightAnchor == view2.heightAnchor / 2 ~ .low
+            view1.widthAnchor |==| view2.widthAnchor
+            view1.heightAnchor |==| view2.heightAnchor / 2 ~ .low
         }
 
         let width = constraints[0]
@@ -559,8 +559,8 @@ class AnchorageTests: XCTestCase {
 
     func testActiveBatchConstraints() {
         let constraints = Anchorage.batch {
-            view1.widthAnchor == view2.widthAnchor
-            view1.heightAnchor == view2.heightAnchor / 2 ~ .low
+            view1.widthAnchor |==| view2.widthAnchor
+            view1.heightAnchor |==| view2.heightAnchor / 2 ~ .low
         }
 
         let width = constraints[0]
@@ -590,11 +590,11 @@ class AnchorageTests: XCTestCase {
     func testNestedBatchConstraints() {
         var nestedConstraints: [NSLayoutConstraint] = []
         let constraints = Anchorage.batch {
-            view1.widthAnchor == view2.widthAnchor
+            view1.widthAnchor |==| view2.widthAnchor
             nestedConstraints = Anchorage.batch(active: false) {
-                view1.heightAnchor == view2.heightAnchor / 2 ~ .low
+                view1.heightAnchor |==| view2.heightAnchor / 2 ~ .low
             }
-            view1.leadingAnchor == view2.leadingAnchor
+            view1.leadingAnchor |==| view2.leadingAnchor
         }
         
         let width = constraints[0]

--- a/README.md
+++ b/README.md
@@ -134,6 +134,16 @@ You can also pass `active: true` if you want the constraints in the array to be 
 
 Anchorage sets the `translatesAutoresizingMaskIntoConstraints` property to `false` on the *left* hand side of the expression, so you should never need to set this property manually. This is important to be aware of in case the container view relies on `translatesAutoresizingMaskIntoConstraints` being set to `true`. We tend to keep child views on the left hand side of the expression to avoid this problem, especially when constraining to a system-supplied view.
 
+## A Note on Compile Times
+
+Anchorage overloads a few Swift operators, which can lead to increased compile times. If you need them, Anchorage provides alternative custom operators that reduce this overhead:
+
+| Operator | Faster Alternative |
+|------|----------|
+| `==` | `\|==\|` |
+| `<=` | `\|<=\|` |
+| `>=` | `\|>=\|` |
+
 # Installation
 
 ## CocoaPods

--- a/README.md
+++ b/README.md
@@ -136,13 +136,15 @@ Anchorage sets the `translatesAutoresizingMaskIntoConstraints` property to `fals
 
 ## A Note on Compile Times
 
-Anchorage overloads a few Swift operators, which can lead to increased compile times. If you need them, Anchorage provides alternative custom operators that reduce this overhead:
+Anchorage overloads a few Swift operators, which can lead to increased compile times. You can reduce this overhead by surrounding these operators with `/`, like so:
 
 | Operator | Faster Alternative |
 |------|----------|
-| `==` | `\|==\|` |
-| `<=` | `\|<=\|` |
-| `>=` | `\|>=\|` |
+| `==` | `/==/` |
+| `<=` | `/<=/` |
+| `>=` | `/>=/` |
+
+For example, `view1.edgeAnchors == view2.edgeAnchors` would become `view1.edgeAnchors /==/ view2.edgeAnchors`.
 
 # Installation
 

--- a/Source/Anchorage.swift
+++ b/Source/Anchorage.swift
@@ -163,6 +163,8 @@ infix operator |==|: ComparisonPrecedence
 
 // MARK: - Inequality Constraints
 
+// MARK: <=
+
 infix operator |<=|: ComparisonPrecedence
 
 @discardableResult public func <= <T: BinaryFloatingPoint>(lhs: NSLayoutDimension, rhs: T) -> NSLayoutConstraint {
@@ -281,6 +283,8 @@ infix operator |<=|: ComparisonPrecedence
 @discardableResult public func |<=| (lhs: AnchorPair<NSLayoutDimension, NSLayoutDimension>, rhs: LayoutExpression<AnchorPair<NSLayoutDimension, NSLayoutDimension>, CGSize>) -> ConstraintPair {
     return lhs.finalize(constraintsLessThanOrEqualToConstant: rhs.constant, priority: rhs.priority)
 }
+
+// MARK: >=
 
 infix operator |>=|: ComparisonPrecedence
 

--- a/Source/Anchorage.swift
+++ b/Source/Anchorage.swift
@@ -42,61 +42,61 @@ extension NSLayoutAnchor: LayoutAnchorType {}
 
 // MARK: - Equality Constraints
 
-infix operator |==|: ComparisonPrecedence
+infix operator /==/: ComparisonPrecedence
 
 @discardableResult public func == <T: BinaryFloatingPoint>(lhs: NSLayoutDimension, rhs: T) -> NSLayoutConstraint {
-    return lhs |==| rhs
+    return lhs /==/ rhs
 }
 
-@discardableResult public func |==| <T: BinaryFloatingPoint>(lhs: NSLayoutDimension, rhs: T) -> NSLayoutConstraint {
+@discardableResult public func /==/ <T: BinaryFloatingPoint>(lhs: NSLayoutDimension, rhs: T) -> NSLayoutConstraint {
     return finalize(constraint: lhs.constraint(equalToConstant: CGFloat(rhs)))
 }
 
 @discardableResult public func == (lhs: NSLayoutXAxisAnchor, rhs: NSLayoutXAxisAnchor) -> NSLayoutConstraint {
-    return lhs |==| rhs
+    return lhs /==/ rhs
 }
 
-@discardableResult public func |==| (lhs: NSLayoutXAxisAnchor, rhs: NSLayoutXAxisAnchor) -> NSLayoutConstraint {
+@discardableResult public func /==/ (lhs: NSLayoutXAxisAnchor, rhs: NSLayoutXAxisAnchor) -> NSLayoutConstraint {
     return finalize(constraint: lhs.constraint(equalTo: rhs))
 }
 
 @discardableResult public func == (lhs: NSLayoutYAxisAnchor, rhs: NSLayoutYAxisAnchor) -> NSLayoutConstraint {
-    return lhs |==| rhs
+    return lhs /==/ rhs
 }
 
-@discardableResult public func |==| (lhs: NSLayoutYAxisAnchor, rhs: NSLayoutYAxisAnchor) -> NSLayoutConstraint {
+@discardableResult public func /==/ (lhs: NSLayoutYAxisAnchor, rhs: NSLayoutYAxisAnchor) -> NSLayoutConstraint {
     return finalize(constraint: lhs.constraint(equalTo: rhs))
 }
 
 @discardableResult public func == (lhs: NSLayoutDimension, rhs: NSLayoutDimension) -> NSLayoutConstraint {
-    return lhs |==| rhs
+    return lhs /==/ rhs
 }
 
-@discardableResult public func |==| (lhs: NSLayoutDimension, rhs: NSLayoutDimension) -> NSLayoutConstraint {
+@discardableResult public func /==/ (lhs: NSLayoutDimension, rhs: NSLayoutDimension) -> NSLayoutConstraint {
     return finalize(constraint: lhs.constraint(equalTo: rhs))
 }
 
 @discardableResult public func == (lhs: NSLayoutXAxisAnchor, rhs: LayoutExpression<NSLayoutXAxisAnchor, CGFloat>) -> NSLayoutConstraint {
-    return lhs |==| rhs
+    return lhs /==/ rhs
 }
 
-@discardableResult public func |==| (lhs: NSLayoutXAxisAnchor, rhs: LayoutExpression<NSLayoutXAxisAnchor, CGFloat>) -> NSLayoutConstraint {
+@discardableResult public func /==/ (lhs: NSLayoutXAxisAnchor, rhs: LayoutExpression<NSLayoutXAxisAnchor, CGFloat>) -> NSLayoutConstraint {
     return finalize(constraint: lhs.constraint(equalTo: rhs.anchor!, multiplier: rhs.multiplier, constant: rhs.constant), withPriority: rhs.priority)
 }
 
 @discardableResult public func == (lhs: NSLayoutYAxisAnchor, rhs: LayoutExpression<NSLayoutYAxisAnchor, CGFloat>) -> NSLayoutConstraint {
-    return lhs |==| rhs
+    return lhs /==/ rhs
 }
 
-@discardableResult public func |==| (lhs: NSLayoutYAxisAnchor, rhs: LayoutExpression<NSLayoutYAxisAnchor, CGFloat>) -> NSLayoutConstraint {
+@discardableResult public func /==/ (lhs: NSLayoutYAxisAnchor, rhs: LayoutExpression<NSLayoutYAxisAnchor, CGFloat>) -> NSLayoutConstraint {
     return finalize(constraint: lhs.constraint(equalTo: rhs.anchor!, multiplier: rhs.multiplier, constant: rhs.constant), withPriority: rhs.priority)
 }
 
 @discardableResult public func == (lhs: NSLayoutDimension, rhs: LayoutExpression<NSLayoutDimension, CGFloat>) -> NSLayoutConstraint {
-    return lhs |==| rhs
+    return lhs /==/ rhs
 }
 
-@discardableResult public func |==| (lhs: NSLayoutDimension, rhs: LayoutExpression<NSLayoutDimension, CGFloat>) -> NSLayoutConstraint {
+@discardableResult public func /==/ (lhs: NSLayoutDimension, rhs: LayoutExpression<NSLayoutDimension, CGFloat>) -> NSLayoutConstraint {
     if let anchor = rhs.anchor {
         return finalize(constraint: lhs.constraint(equalTo: anchor, multiplier: rhs.multiplier, constant: rhs.constant), withPriority: rhs.priority)
     }
@@ -106,58 +106,58 @@ infix operator |==|: ComparisonPrecedence
 }
 
 @discardableResult public func == (lhs: EdgeAnchors, rhs: EdgeAnchors) -> ConstraintGroup {
-    return lhs |==| rhs
+    return lhs /==/ rhs
 }
 
-@discardableResult public func |==| (lhs: EdgeAnchors, rhs: EdgeAnchors) -> ConstraintGroup {
+@discardableResult public func /==/ (lhs: EdgeAnchors, rhs: EdgeAnchors) -> ConstraintGroup {
     return lhs.finalize(constraintsEqualToEdges: rhs)
 }
 
 @discardableResult public func == (lhs: EdgeAnchors, rhs: LayoutExpression<EdgeAnchors, CGFloat>) -> ConstraintGroup {
-    return lhs |==| rhs
+    return lhs /==/ rhs
 }
 
-@discardableResult public func |==| (lhs: EdgeAnchors, rhs: LayoutExpression<EdgeAnchors, CGFloat>) -> ConstraintGroup {
+@discardableResult public func /==/ (lhs: EdgeAnchors, rhs: LayoutExpression<EdgeAnchors, CGFloat>) -> ConstraintGroup {
     return lhs.finalize(constraintsEqualToEdges: rhs.anchor, constant: rhs.constant, priority: rhs.priority)
 }
 
 @discardableResult public func == (lhs: EdgeAnchors, rhs: LayoutExpression<EdgeAnchors, EdgeInsets>) -> ConstraintGroup {
-    return lhs |==| rhs
+    return lhs /==/ rhs
 }
 
-@discardableResult public func |==| (lhs: EdgeAnchors, rhs: LayoutExpression<EdgeAnchors, EdgeInsets>) -> ConstraintGroup {
+@discardableResult public func /==/ (lhs: EdgeAnchors, rhs: LayoutExpression<EdgeAnchors, EdgeInsets>) -> ConstraintGroup {
     return lhs.finalize(constraintsEqualToEdges: rhs.anchor, insets: rhs.constant, priority: rhs.priority)
 }
 
 @discardableResult public func == <T, U>(lhs: AnchorPair<T, U>, rhs: AnchorPair<T, U>) -> ConstraintPair {
-    return lhs |==| rhs
+    return lhs /==/ rhs
 }
 
-@discardableResult public func |==| <T, U>(lhs: AnchorPair<T, U>, rhs: AnchorPair<T, U>) -> ConstraintPair {
+@discardableResult public func /==/ <T, U>(lhs: AnchorPair<T, U>, rhs: AnchorPair<T, U>) -> ConstraintPair {
     return lhs.finalize(constraintsEqualToEdges: rhs)
 }
 
 @discardableResult public func == <T, U>(lhs: AnchorPair<T, U>, rhs: LayoutExpression<AnchorPair<T, U>, CGFloat>) -> ConstraintPair {
-    return lhs |==| rhs
+    return lhs /==/ rhs
 }
 
-@discardableResult public func |==| <T, U>(lhs: AnchorPair<T, U>, rhs: LayoutExpression<AnchorPair<T, U>, CGFloat>) -> ConstraintPair {
+@discardableResult public func /==/ <T, U>(lhs: AnchorPair<T, U>, rhs: LayoutExpression<AnchorPair<T, U>, CGFloat>) -> ConstraintPair {
     return lhs.finalize(constraintsEqualToEdges: rhs.anchor, constant: rhs.constant, priority: rhs.priority)
 }
 
 @discardableResult public func == (lhs: AnchorPair<NSLayoutDimension, NSLayoutDimension>, rhs: CGSize) -> ConstraintPair {
-    return lhs |==| rhs
+    return lhs /==/ rhs
 }
 
-@discardableResult public func |==| (lhs: AnchorPair<NSLayoutDimension, NSLayoutDimension>, rhs: CGSize) -> ConstraintPair {
+@discardableResult public func /==/ (lhs: AnchorPair<NSLayoutDimension, NSLayoutDimension>, rhs: CGSize) -> ConstraintPair {
     return lhs.finalize(constraintsEqualToConstant: rhs)
 }
 
 @discardableResult public func == (lhs: AnchorPair<NSLayoutDimension, NSLayoutDimension>, rhs: LayoutExpression<AnchorPair<NSLayoutDimension, NSLayoutDimension>, CGSize>) -> ConstraintPair {
-    return lhs |==| rhs
+    return lhs /==/ rhs
 }
 
-@discardableResult public func |==| (lhs: AnchorPair<NSLayoutDimension, NSLayoutDimension>, rhs: LayoutExpression<AnchorPair<NSLayoutDimension, NSLayoutDimension>, CGSize>) -> ConstraintPair {
+@discardableResult public func /==/ (lhs: AnchorPair<NSLayoutDimension, NSLayoutDimension>, rhs: LayoutExpression<AnchorPair<NSLayoutDimension, NSLayoutDimension>, CGSize>) -> ConstraintPair {
     return lhs.finalize(constraintsEqualToConstant: rhs.constant, priority: rhs.priority)
 }
 
@@ -165,61 +165,61 @@ infix operator |==|: ComparisonPrecedence
 
 // MARK: <=
 
-infix operator |<=|: ComparisonPrecedence
+infix operator /<=/: ComparisonPrecedence
 
 @discardableResult public func <= <T: BinaryFloatingPoint>(lhs: NSLayoutDimension, rhs: T) -> NSLayoutConstraint {
-    return lhs |<=| rhs
+    return lhs /<=/ rhs
 }
 
-@discardableResult public func |<=| <T: BinaryFloatingPoint>(lhs: NSLayoutDimension, rhs: T) -> NSLayoutConstraint {
+@discardableResult public func /<=/ <T: BinaryFloatingPoint>(lhs: NSLayoutDimension, rhs: T) -> NSLayoutConstraint {
     return finalize(constraint: lhs.constraint(lessThanOrEqualToConstant: CGFloat(rhs)))
 }
 
 @discardableResult public func <= (lhs: NSLayoutXAxisAnchor, rhs: NSLayoutXAxisAnchor) -> NSLayoutConstraint {
-    return lhs |<=| rhs
+    return lhs /<=/ rhs
 }
 
-@discardableResult public func |<=| (lhs: NSLayoutXAxisAnchor, rhs: NSLayoutXAxisAnchor) -> NSLayoutConstraint {
+@discardableResult public func /<=/ (lhs: NSLayoutXAxisAnchor, rhs: NSLayoutXAxisAnchor) -> NSLayoutConstraint {
     return finalize(constraint: lhs.constraint(lessThanOrEqualTo: rhs))
 }
 
 @discardableResult public func <= (lhs: NSLayoutYAxisAnchor, rhs: NSLayoutYAxisAnchor) -> NSLayoutConstraint {
-    return lhs |<=| rhs
+    return lhs /<=/ rhs
 }
 
-@discardableResult public func |<=| (lhs: NSLayoutYAxisAnchor, rhs: NSLayoutYAxisAnchor) -> NSLayoutConstraint {
+@discardableResult public func /<=/ (lhs: NSLayoutYAxisAnchor, rhs: NSLayoutYAxisAnchor) -> NSLayoutConstraint {
     return finalize(constraint: lhs.constraint(lessThanOrEqualTo: rhs))
 }
 
 @discardableResult public func <= (lhs: NSLayoutDimension, rhs: NSLayoutDimension) -> NSLayoutConstraint {
-    return lhs |<=| rhs
+    return lhs /<=/ rhs
 }
 
-@discardableResult public func |<=| (lhs: NSLayoutDimension, rhs: NSLayoutDimension) -> NSLayoutConstraint {
+@discardableResult public func /<=/ (lhs: NSLayoutDimension, rhs: NSLayoutDimension) -> NSLayoutConstraint {
     return finalize(constraint: lhs.constraint(lessThanOrEqualTo: rhs))
 }
 
 @discardableResult public func <= (lhs: NSLayoutXAxisAnchor, rhs: LayoutExpression<NSLayoutXAxisAnchor, CGFloat>) -> NSLayoutConstraint {
-    return lhs |<=| rhs
+    return lhs /<=/ rhs
 }
 
-@discardableResult public func |<=| (lhs: NSLayoutXAxisAnchor, rhs: LayoutExpression<NSLayoutXAxisAnchor, CGFloat>) -> NSLayoutConstraint {
+@discardableResult public func /<=/ (lhs: NSLayoutXAxisAnchor, rhs: LayoutExpression<NSLayoutXAxisAnchor, CGFloat>) -> NSLayoutConstraint {
     return finalize(constraint: lhs.constraint(lessThanOrEqualTo: rhs.anchor!, multiplier: rhs.multiplier, constant: rhs.constant), withPriority: rhs.priority)
 }
 
 @discardableResult public func <= (lhs: NSLayoutYAxisAnchor, rhs: LayoutExpression<NSLayoutYAxisAnchor, CGFloat>) -> NSLayoutConstraint {
-    return lhs |<=| rhs
+    return lhs /<=/ rhs
 }
 
-@discardableResult public func |<=| (lhs: NSLayoutYAxisAnchor, rhs: LayoutExpression<NSLayoutYAxisAnchor, CGFloat>) -> NSLayoutConstraint {
+@discardableResult public func /<=/ (lhs: NSLayoutYAxisAnchor, rhs: LayoutExpression<NSLayoutYAxisAnchor, CGFloat>) -> NSLayoutConstraint {
     return finalize(constraint: lhs.constraint(lessThanOrEqualTo: rhs.anchor!, multiplier: rhs.multiplier, constant: rhs.constant), withPriority: rhs.priority)
 }
 
 @discardableResult public func <= (lhs: NSLayoutDimension, rhs: LayoutExpression<NSLayoutDimension, CGFloat>) -> NSLayoutConstraint {
-    return lhs |<=| rhs
+    return lhs /<=/ rhs
 }
 
-@discardableResult public func |<=| (lhs: NSLayoutDimension, rhs: LayoutExpression<NSLayoutDimension, CGFloat>) -> NSLayoutConstraint {
+@discardableResult public func /<=/ (lhs: NSLayoutDimension, rhs: LayoutExpression<NSLayoutDimension, CGFloat>) -> NSLayoutConstraint {
     if let anchor = rhs.anchor {
         return finalize(constraint: lhs.constraint(lessThanOrEqualTo: anchor, multiplier: rhs.multiplier, constant: rhs.constant), withPriority: rhs.priority)
     }
@@ -229,118 +229,118 @@ infix operator |<=|: ComparisonPrecedence
 }
 
 @discardableResult public func <= (lhs: EdgeAnchors, rhs: EdgeAnchors) -> ConstraintGroup {
-    return lhs |<=| rhs
+    return lhs /<=/ rhs
 }
 
-@discardableResult public func |<=| (lhs: EdgeAnchors, rhs: EdgeAnchors) -> ConstraintGroup {
+@discardableResult public func /<=/ (lhs: EdgeAnchors, rhs: EdgeAnchors) -> ConstraintGroup {
     return lhs.finalize(constraintsLessThanOrEqualToEdges: rhs)
 }
 
 @discardableResult public func <= (lhs: EdgeAnchors, rhs: LayoutExpression<EdgeAnchors, CGFloat>) -> ConstraintGroup {
-    return lhs |<=| rhs
+    return lhs /<=/ rhs
 }
 
-@discardableResult public func |<=| (lhs: EdgeAnchors, rhs: LayoutExpression<EdgeAnchors, CGFloat>) -> ConstraintGroup {
+@discardableResult public func /<=/ (lhs: EdgeAnchors, rhs: LayoutExpression<EdgeAnchors, CGFloat>) -> ConstraintGroup {
     return lhs.finalize(constraintsLessThanOrEqualToEdges: rhs.anchor, constant: rhs.constant, priority: rhs.priority)
 }
 
 @discardableResult public func <= (lhs: EdgeAnchors, rhs: LayoutExpression<EdgeAnchors, EdgeInsets>) -> ConstraintGroup {
-    return lhs |<=| rhs
+    return lhs /<=/ rhs
 }
 
-@discardableResult public func |<=| (lhs: EdgeAnchors, rhs: LayoutExpression<EdgeAnchors, EdgeInsets>) -> ConstraintGroup {
+@discardableResult public func /<=/ (lhs: EdgeAnchors, rhs: LayoutExpression<EdgeAnchors, EdgeInsets>) -> ConstraintGroup {
     return lhs.finalize(constraintsLessThanOrEqualToEdges: rhs.anchor, insets: rhs.constant, priority: rhs.priority)
 }
 
 @discardableResult public func <= <T, U>(lhs: AnchorPair<T, U>, rhs: AnchorPair<T, U>) -> ConstraintPair {
-    return lhs |<=| rhs
+    return lhs /<=/ rhs
 }
 
-@discardableResult public func |<=| <T, U>(lhs: AnchorPair<T, U>, rhs: AnchorPair<T, U>) -> ConstraintPair {
+@discardableResult public func /<=/ <T, U>(lhs: AnchorPair<T, U>, rhs: AnchorPair<T, U>) -> ConstraintPair {
     return lhs.finalize(constraintsLessThanOrEqualToEdges: rhs)
 }
 
 @discardableResult public func <= <T, U>(lhs: AnchorPair<T, U>, rhs: LayoutExpression<AnchorPair<T, U>, CGFloat>) -> ConstraintPair {
-    return lhs |<=| rhs
+    return lhs /<=/ rhs
 }
 
-@discardableResult public func |<=| <T, U>(lhs: AnchorPair<T, U>, rhs: LayoutExpression<AnchorPair<T, U>, CGFloat>) -> ConstraintPair {
+@discardableResult public func /<=/ <T, U>(lhs: AnchorPair<T, U>, rhs: LayoutExpression<AnchorPair<T, U>, CGFloat>) -> ConstraintPair {
     return lhs.finalize(constraintsLessThanOrEqualToEdges: rhs.anchor, constant: rhs.constant, priority: rhs.priority)
 }
 
 @discardableResult public func <= (lhs: AnchorPair<NSLayoutDimension, NSLayoutDimension>, rhs: CGSize) -> ConstraintPair {
-    return lhs |<=| rhs
+    return lhs /<=/ rhs
 }
 
-@discardableResult public func |<=| (lhs: AnchorPair<NSLayoutDimension, NSLayoutDimension>, rhs: CGSize) -> ConstraintPair {
+@discardableResult public func /<=/ (lhs: AnchorPair<NSLayoutDimension, NSLayoutDimension>, rhs: CGSize) -> ConstraintPair {
     return lhs.finalize(constraintsLessThanOrEqualToConstant: rhs)
 }
 
 @discardableResult public func <= (lhs: AnchorPair<NSLayoutDimension, NSLayoutDimension>, rhs: LayoutExpression<AnchorPair<NSLayoutDimension, NSLayoutDimension>, CGSize>) -> ConstraintPair {
-    return lhs |<=| rhs
+    return lhs /<=/ rhs
 }
 
-@discardableResult public func |<=| (lhs: AnchorPair<NSLayoutDimension, NSLayoutDimension>, rhs: LayoutExpression<AnchorPair<NSLayoutDimension, NSLayoutDimension>, CGSize>) -> ConstraintPair {
+@discardableResult public func /<=/ (lhs: AnchorPair<NSLayoutDimension, NSLayoutDimension>, rhs: LayoutExpression<AnchorPair<NSLayoutDimension, NSLayoutDimension>, CGSize>) -> ConstraintPair {
     return lhs.finalize(constraintsLessThanOrEqualToConstant: rhs.constant, priority: rhs.priority)
 }
 
 // MARK: >=
 
-infix operator |>=|: ComparisonPrecedence
+infix operator />=/: ComparisonPrecedence
 
 @discardableResult public func >= <T: BinaryFloatingPoint>(lhs: NSLayoutDimension, rhs: T) -> NSLayoutConstraint {
-    return lhs |>=| rhs
+    return lhs />=/ rhs
 }
 
-@discardableResult public func |>=| <T: BinaryFloatingPoint>(lhs: NSLayoutDimension, rhs: T) -> NSLayoutConstraint {
+@discardableResult public func />=/ <T: BinaryFloatingPoint>(lhs: NSLayoutDimension, rhs: T) -> NSLayoutConstraint {
     return finalize(constraint: lhs.constraint(greaterThanOrEqualToConstant: CGFloat(rhs)))
 }
 
 @discardableResult public func >= (lhs: NSLayoutXAxisAnchor, rhs: NSLayoutXAxisAnchor) -> NSLayoutConstraint {
-    return lhs |>=| rhs
+    return lhs />=/ rhs
 }
 
-@discardableResult public func |>=| (lhs: NSLayoutXAxisAnchor, rhs: NSLayoutXAxisAnchor) -> NSLayoutConstraint {
+@discardableResult public func />=/ (lhs: NSLayoutXAxisAnchor, rhs: NSLayoutXAxisAnchor) -> NSLayoutConstraint {
     return finalize(constraint: lhs.constraint(greaterThanOrEqualTo: rhs))
 }
 
 @discardableResult public func >= (lhs: NSLayoutYAxisAnchor, rhs: NSLayoutYAxisAnchor) -> NSLayoutConstraint {
-    return lhs |>=| rhs
+    return lhs />=/ rhs
 }
 
-@discardableResult public func |>=| (lhs: NSLayoutYAxisAnchor, rhs: NSLayoutYAxisAnchor) -> NSLayoutConstraint {
+@discardableResult public func />=/ (lhs: NSLayoutYAxisAnchor, rhs: NSLayoutYAxisAnchor) -> NSLayoutConstraint {
     return finalize(constraint: lhs.constraint(greaterThanOrEqualTo: rhs))
 }
 
 @discardableResult public func >= (lhs: NSLayoutDimension, rhs: NSLayoutDimension) -> NSLayoutConstraint {
-    return lhs |>=| rhs
+    return lhs />=/ rhs
 }
 
-@discardableResult public func |>=| (lhs: NSLayoutDimension, rhs: NSLayoutDimension) -> NSLayoutConstraint {
+@discardableResult public func />=/ (lhs: NSLayoutDimension, rhs: NSLayoutDimension) -> NSLayoutConstraint {
     return finalize(constraint: lhs.constraint(greaterThanOrEqualTo: rhs))
 }
 
 @discardableResult public func >= (lhs: NSLayoutXAxisAnchor, rhs: LayoutExpression<NSLayoutXAxisAnchor, CGFloat>) -> NSLayoutConstraint {
-    return lhs |>=| rhs
+    return lhs />=/ rhs
 }
 
-@discardableResult public func |>=| (lhs: NSLayoutXAxisAnchor, rhs: LayoutExpression<NSLayoutXAxisAnchor, CGFloat>) -> NSLayoutConstraint {
+@discardableResult public func />=/ (lhs: NSLayoutXAxisAnchor, rhs: LayoutExpression<NSLayoutXAxisAnchor, CGFloat>) -> NSLayoutConstraint {
     return finalize(constraint: lhs.constraint(greaterThanOrEqualTo: rhs.anchor!, multiplier: rhs.multiplier, constant: rhs.constant), withPriority: rhs.priority)
 }
 
 @discardableResult public func >= (lhs: NSLayoutYAxisAnchor, rhs: LayoutExpression<NSLayoutYAxisAnchor, CGFloat>) -> NSLayoutConstraint {
-    return lhs |>=| rhs
+    return lhs />=/ rhs
 }
 
-@discardableResult public func |>=| (lhs: NSLayoutYAxisAnchor, rhs: LayoutExpression<NSLayoutYAxisAnchor, CGFloat>) -> NSLayoutConstraint {
+@discardableResult public func />=/ (lhs: NSLayoutYAxisAnchor, rhs: LayoutExpression<NSLayoutYAxisAnchor, CGFloat>) -> NSLayoutConstraint {
     return finalize(constraint: lhs.constraint(greaterThanOrEqualTo: rhs.anchor!, multiplier: rhs.multiplier, constant: rhs.constant), withPriority: rhs.priority)
 }
 
 @discardableResult public func >= (lhs: NSLayoutDimension, rhs: LayoutExpression<NSLayoutDimension, CGFloat>) -> NSLayoutConstraint {
-    return lhs |>=| rhs
+    return lhs />=/ rhs
 }
 
-@discardableResult public func |>=| (lhs: NSLayoutDimension, rhs: LayoutExpression<NSLayoutDimension, CGFloat>) -> NSLayoutConstraint {
+@discardableResult public func />=/ (lhs: NSLayoutDimension, rhs: LayoutExpression<NSLayoutDimension, CGFloat>) -> NSLayoutConstraint {
     if let anchor = rhs.anchor {
         return finalize(constraint: lhs.constraint(greaterThanOrEqualTo: anchor, multiplier: rhs.multiplier, constant: rhs.constant), withPriority: rhs.priority)
     }
@@ -350,58 +350,58 @@ infix operator |>=|: ComparisonPrecedence
 }
 
 @discardableResult public func >= (lhs: EdgeAnchors, rhs: EdgeAnchors) -> ConstraintGroup {
-    return lhs |>=| rhs
+    return lhs />=/ rhs
 }
 
-@discardableResult public func |>=| (lhs: EdgeAnchors, rhs: EdgeAnchors) -> ConstraintGroup {
+@discardableResult public func />=/ (lhs: EdgeAnchors, rhs: EdgeAnchors) -> ConstraintGroup {
     return lhs.finalize(constraintsGreaterThanOrEqualToEdges: rhs)
 }
 
 @discardableResult public func >= (lhs: EdgeAnchors, rhs: LayoutExpression<EdgeAnchors, CGFloat>) -> ConstraintGroup {
-    return lhs |>=| rhs
+    return lhs />=/ rhs
 }
 
-@discardableResult public func |>=| (lhs: EdgeAnchors, rhs: LayoutExpression<EdgeAnchors, CGFloat>) -> ConstraintGroup {
+@discardableResult public func />=/ (lhs: EdgeAnchors, rhs: LayoutExpression<EdgeAnchors, CGFloat>) -> ConstraintGroup {
     return lhs.finalize(constraintsGreaterThanOrEqualToEdges: rhs.anchor, constant: rhs.constant, priority: rhs.priority)
 }
 
 @discardableResult public func >= (lhs: EdgeAnchors, rhs: LayoutExpression<EdgeAnchors, EdgeInsets>) -> ConstraintGroup {
-    return lhs |>=| rhs
+    return lhs />=/ rhs
 }
 
-@discardableResult public func |>=| (lhs: EdgeAnchors, rhs: LayoutExpression<EdgeAnchors, EdgeInsets>) -> ConstraintGroup {
+@discardableResult public func />=/ (lhs: EdgeAnchors, rhs: LayoutExpression<EdgeAnchors, EdgeInsets>) -> ConstraintGroup {
     return lhs.finalize(constraintsGreaterThanOrEqualToEdges: rhs.anchor, insets: rhs.constant, priority: rhs.priority)
 }
 
 @discardableResult public func >= <T, U>(lhs: AnchorPair<T, U>, rhs: AnchorPair<T, U>) -> ConstraintPair {
-    return lhs |>=| rhs
+    return lhs />=/ rhs
 }
 
-@discardableResult public func |>=| <T, U>(lhs: AnchorPair<T, U>, rhs: AnchorPair<T, U>) -> ConstraintPair {
+@discardableResult public func />=/ <T, U>(lhs: AnchorPair<T, U>, rhs: AnchorPair<T, U>) -> ConstraintPair {
     return lhs.finalize(constraintsGreaterThanOrEqualToEdges: rhs)
 }
 
 @discardableResult public func >= <T, U>(lhs: AnchorPair<T, U>, rhs: LayoutExpression<AnchorPair<T, U>, CGFloat>) -> ConstraintPair {
-    return lhs |>=| rhs
+    return lhs />=/ rhs
 }
 
-@discardableResult public func |>=| <T, U>(lhs: AnchorPair<T, U>, rhs: LayoutExpression<AnchorPair<T, U>, CGFloat>) -> ConstraintPair {
+@discardableResult public func />=/ <T, U>(lhs: AnchorPair<T, U>, rhs: LayoutExpression<AnchorPair<T, U>, CGFloat>) -> ConstraintPair {
     return lhs.finalize(constraintsGreaterThanOrEqualToEdges: rhs.anchor, constant: rhs.constant, priority: rhs.priority)
 }
 
 @discardableResult public func >= (lhs: AnchorPair<NSLayoutDimension, NSLayoutDimension>, rhs: CGSize) -> ConstraintPair {
-    return lhs |>=| rhs
+    return lhs />=/ rhs
 }
 
-@discardableResult public func |>=| (lhs: AnchorPair<NSLayoutDimension, NSLayoutDimension>, rhs: CGSize) -> ConstraintPair {
+@discardableResult public func />=/ (lhs: AnchorPair<NSLayoutDimension, NSLayoutDimension>, rhs: CGSize) -> ConstraintPair {
     return lhs.finalize(constraintsGreaterThanOrEqualToConstant: rhs)
 }
 
 @discardableResult public func >= (lhs: AnchorPair<NSLayoutDimension, NSLayoutDimension>, rhs: LayoutExpression<AnchorPair<NSLayoutDimension, NSLayoutDimension>, CGSize>) -> ConstraintPair {
-    return lhs |>=| rhs
+    return lhs />=/ rhs
 }
 
-@discardableResult public func |>=| (lhs: AnchorPair<NSLayoutDimension, NSLayoutDimension>, rhs: LayoutExpression<AnchorPair<NSLayoutDimension, NSLayoutDimension>, CGSize>) -> ConstraintPair {
+@discardableResult public func />=/ (lhs: AnchorPair<NSLayoutDimension, NSLayoutDimension>, rhs: LayoutExpression<AnchorPair<NSLayoutDimension, NSLayoutDimension>, CGSize>) -> ConstraintPair {
     return lhs.finalize(constraintsGreaterThanOrEqualToConstant: rhs.constant, priority: rhs.priority)
 }
 

--- a/Source/Anchorage.swift
+++ b/Source/Anchorage.swift
@@ -163,7 +163,7 @@ infix operator /==/: ComparisonPrecedence
 
 // MARK: - Inequality Constraints
 
-// MARK: <=
+// MARK: Less Than or Equal To
 
 infix operator /<=/: ComparisonPrecedence
 
@@ -284,7 +284,7 @@ infix operator /<=/: ComparisonPrecedence
     return lhs.finalize(constraintsLessThanOrEqualToConstant: rhs.constant, priority: rhs.priority)
 }
 
-// MARK: >=
+// MARK: Greater Than or Equal To
 
 infix operator />=/: ComparisonPrecedence
 

--- a/Source/Anchorage.swift
+++ b/Source/Anchorage.swift
@@ -42,31 +42,61 @@ extension NSLayoutAnchor: LayoutAnchorType {}
 
 // MARK: - Equality Constraints
 
+infix operator |==|: ComparisonPrecedence
+
 @discardableResult public func == <T: BinaryFloatingPoint>(lhs: NSLayoutDimension, rhs: T) -> NSLayoutConstraint {
+    return lhs |==| rhs
+}
+
+@discardableResult public func |==| <T: BinaryFloatingPoint>(lhs: NSLayoutDimension, rhs: T) -> NSLayoutConstraint {
     return finalize(constraint: lhs.constraint(equalToConstant: CGFloat(rhs)))
 }
 
 @discardableResult public func == (lhs: NSLayoutXAxisAnchor, rhs: NSLayoutXAxisAnchor) -> NSLayoutConstraint {
+    return lhs |==| rhs
+}
+
+@discardableResult public func |==| (lhs: NSLayoutXAxisAnchor, rhs: NSLayoutXAxisAnchor) -> NSLayoutConstraint {
     return finalize(constraint: lhs.constraint(equalTo: rhs))
 }
 
 @discardableResult public func == (lhs: NSLayoutYAxisAnchor, rhs: NSLayoutYAxisAnchor) -> NSLayoutConstraint {
+    return lhs |==| rhs
+}
+
+@discardableResult public func |==| (lhs: NSLayoutYAxisAnchor, rhs: NSLayoutYAxisAnchor) -> NSLayoutConstraint {
     return finalize(constraint: lhs.constraint(equalTo: rhs))
 }
 
 @discardableResult public func == (lhs: NSLayoutDimension, rhs: NSLayoutDimension) -> NSLayoutConstraint {
+    return lhs |==| rhs
+}
+
+@discardableResult public func |==| (lhs: NSLayoutDimension, rhs: NSLayoutDimension) -> NSLayoutConstraint {
     return finalize(constraint: lhs.constraint(equalTo: rhs))
 }
 
 @discardableResult public func == (lhs: NSLayoutXAxisAnchor, rhs: LayoutExpression<NSLayoutXAxisAnchor, CGFloat>) -> NSLayoutConstraint {
+    return lhs |==| rhs
+}
+
+@discardableResult public func |==| (lhs: NSLayoutXAxisAnchor, rhs: LayoutExpression<NSLayoutXAxisAnchor, CGFloat>) -> NSLayoutConstraint {
     return finalize(constraint: lhs.constraint(equalTo: rhs.anchor!, multiplier: rhs.multiplier, constant: rhs.constant), withPriority: rhs.priority)
 }
 
 @discardableResult public func == (lhs: NSLayoutYAxisAnchor, rhs: LayoutExpression<NSLayoutYAxisAnchor, CGFloat>) -> NSLayoutConstraint {
+    return lhs |==| rhs
+}
+
+@discardableResult public func |==| (lhs: NSLayoutYAxisAnchor, rhs: LayoutExpression<NSLayoutYAxisAnchor, CGFloat>) -> NSLayoutConstraint {
     return finalize(constraint: lhs.constraint(equalTo: rhs.anchor!, multiplier: rhs.multiplier, constant: rhs.constant), withPriority: rhs.priority)
 }
 
 @discardableResult public func == (lhs: NSLayoutDimension, rhs: LayoutExpression<NSLayoutDimension, CGFloat>) -> NSLayoutConstraint {
+    return lhs |==| rhs
+}
+
+@discardableResult public func |==| (lhs: NSLayoutDimension, rhs: LayoutExpression<NSLayoutDimension, CGFloat>) -> NSLayoutConstraint {
     if let anchor = rhs.anchor {
         return finalize(constraint: lhs.constraint(equalTo: anchor, multiplier: rhs.multiplier, constant: rhs.constant), withPriority: rhs.priority)
     }
@@ -76,60 +106,118 @@ extension NSLayoutAnchor: LayoutAnchorType {}
 }
 
 @discardableResult public func == (lhs: EdgeAnchors, rhs: EdgeAnchors) -> ConstraintGroup {
+    return lhs |==| rhs
+}
+
+@discardableResult public func |==| (lhs: EdgeAnchors, rhs: EdgeAnchors) -> ConstraintGroup {
     return lhs.finalize(constraintsEqualToEdges: rhs)
 }
 
 @discardableResult public func == (lhs: EdgeAnchors, rhs: LayoutExpression<EdgeAnchors, CGFloat>) -> ConstraintGroup {
+    return lhs |==| rhs
+}
+
+@discardableResult public func |==| (lhs: EdgeAnchors, rhs: LayoutExpression<EdgeAnchors, CGFloat>) -> ConstraintGroup {
     return lhs.finalize(constraintsEqualToEdges: rhs.anchor, constant: rhs.constant, priority: rhs.priority)
 }
 
 @discardableResult public func == (lhs: EdgeAnchors, rhs: LayoutExpression<EdgeAnchors, EdgeInsets>) -> ConstraintGroup {
+    return lhs |==| rhs
+}
+
+@discardableResult public func |==| (lhs: EdgeAnchors, rhs: LayoutExpression<EdgeAnchors, EdgeInsets>) -> ConstraintGroup {
     return lhs.finalize(constraintsEqualToEdges: rhs.anchor, insets: rhs.constant, priority: rhs.priority)
 }
 
 @discardableResult public func == <T, U>(lhs: AnchorPair<T, U>, rhs: AnchorPair<T, U>) -> ConstraintPair {
+    return lhs |==| rhs
+}
+
+@discardableResult public func |==| <T, U>(lhs: AnchorPair<T, U>, rhs: AnchorPair<T, U>) -> ConstraintPair {
     return lhs.finalize(constraintsEqualToEdges: rhs)
 }
 
 @discardableResult public func == <T, U>(lhs: AnchorPair<T, U>, rhs: LayoutExpression<AnchorPair<T, U>, CGFloat>) -> ConstraintPair {
+    return lhs |==| rhs
+}
+
+@discardableResult public func |==| <T, U>(lhs: AnchorPair<T, U>, rhs: LayoutExpression<AnchorPair<T, U>, CGFloat>) -> ConstraintPair {
     return lhs.finalize(constraintsEqualToEdges: rhs.anchor, constant: rhs.constant, priority: rhs.priority)
 }
 
 @discardableResult public func == (lhs: AnchorPair<NSLayoutDimension, NSLayoutDimension>, rhs: CGSize) -> ConstraintPair {
+    return lhs |==| rhs
+}
+
+@discardableResult public func |==| (lhs: AnchorPair<NSLayoutDimension, NSLayoutDimension>, rhs: CGSize) -> ConstraintPair {
     return lhs.finalize(constraintsEqualToConstant: rhs)
 }
 
 @discardableResult public func == (lhs: AnchorPair<NSLayoutDimension, NSLayoutDimension>, rhs: LayoutExpression<AnchorPair<NSLayoutDimension, NSLayoutDimension>, CGSize>) -> ConstraintPair {
+    return lhs |==| rhs
+}
+
+@discardableResult public func |==| (lhs: AnchorPair<NSLayoutDimension, NSLayoutDimension>, rhs: LayoutExpression<AnchorPair<NSLayoutDimension, NSLayoutDimension>, CGSize>) -> ConstraintPair {
     return lhs.finalize(constraintsEqualToConstant: rhs.constant, priority: rhs.priority)
 }
 
 // MARK: - Inequality Constraints
 
+infix operator |<=|: ComparisonPrecedence
+
 @discardableResult public func <= <T: BinaryFloatingPoint>(lhs: NSLayoutDimension, rhs: T) -> NSLayoutConstraint {
+    return lhs |<=| rhs
+}
+
+@discardableResult public func |<=| <T: BinaryFloatingPoint>(lhs: NSLayoutDimension, rhs: T) -> NSLayoutConstraint {
     return finalize(constraint: lhs.constraint(lessThanOrEqualToConstant: CGFloat(rhs)))
 }
 
 @discardableResult public func <= (lhs: NSLayoutXAxisAnchor, rhs: NSLayoutXAxisAnchor) -> NSLayoutConstraint {
+    return lhs |<=| rhs
+}
+
+@discardableResult public func |<=| (lhs: NSLayoutXAxisAnchor, rhs: NSLayoutXAxisAnchor) -> NSLayoutConstraint {
     return finalize(constraint: lhs.constraint(lessThanOrEqualTo: rhs))
 }
 
 @discardableResult public func <= (lhs: NSLayoutYAxisAnchor, rhs: NSLayoutYAxisAnchor) -> NSLayoutConstraint {
+    return lhs |<=| rhs
+}
+
+@discardableResult public func |<=| (lhs: NSLayoutYAxisAnchor, rhs: NSLayoutYAxisAnchor) -> NSLayoutConstraint {
     return finalize(constraint: lhs.constraint(lessThanOrEqualTo: rhs))
 }
 
 @discardableResult public func <= (lhs: NSLayoutDimension, rhs: NSLayoutDimension) -> NSLayoutConstraint {
+    return lhs |<=| rhs
+}
+
+@discardableResult public func |<=| (lhs: NSLayoutDimension, rhs: NSLayoutDimension) -> NSLayoutConstraint {
     return finalize(constraint: lhs.constraint(lessThanOrEqualTo: rhs))
 }
 
 @discardableResult public func <= (lhs: NSLayoutXAxisAnchor, rhs: LayoutExpression<NSLayoutXAxisAnchor, CGFloat>) -> NSLayoutConstraint {
+    return lhs |<=| rhs
+}
+
+@discardableResult public func |<=| (lhs: NSLayoutXAxisAnchor, rhs: LayoutExpression<NSLayoutXAxisAnchor, CGFloat>) -> NSLayoutConstraint {
     return finalize(constraint: lhs.constraint(lessThanOrEqualTo: rhs.anchor!, multiplier: rhs.multiplier, constant: rhs.constant), withPriority: rhs.priority)
 }
 
 @discardableResult public func <= (lhs: NSLayoutYAxisAnchor, rhs: LayoutExpression<NSLayoutYAxisAnchor, CGFloat>) -> NSLayoutConstraint {
+    return lhs |<=| rhs
+}
+
+@discardableResult public func |<=| (lhs: NSLayoutYAxisAnchor, rhs: LayoutExpression<NSLayoutYAxisAnchor, CGFloat>) -> NSLayoutConstraint {
     return finalize(constraint: lhs.constraint(lessThanOrEqualTo: rhs.anchor!, multiplier: rhs.multiplier, constant: rhs.constant), withPriority: rhs.priority)
 }
 
 @discardableResult public func <= (lhs: NSLayoutDimension, rhs: LayoutExpression<NSLayoutDimension, CGFloat>) -> NSLayoutConstraint {
+    return lhs |<=| rhs
+}
+
+@discardableResult public func |<=| (lhs: NSLayoutDimension, rhs: LayoutExpression<NSLayoutDimension, CGFloat>) -> NSLayoutConstraint {
     if let anchor = rhs.anchor {
         return finalize(constraint: lhs.constraint(lessThanOrEqualTo: anchor, multiplier: rhs.multiplier, constant: rhs.constant), withPriority: rhs.priority)
     }
@@ -139,58 +227,116 @@ extension NSLayoutAnchor: LayoutAnchorType {}
 }
 
 @discardableResult public func <= (lhs: EdgeAnchors, rhs: EdgeAnchors) -> ConstraintGroup {
+    return lhs |<=| rhs
+}
+
+@discardableResult public func |<=| (lhs: EdgeAnchors, rhs: EdgeAnchors) -> ConstraintGroup {
     return lhs.finalize(constraintsLessThanOrEqualToEdges: rhs)
 }
 
 @discardableResult public func <= (lhs: EdgeAnchors, rhs: LayoutExpression<EdgeAnchors, CGFloat>) -> ConstraintGroup {
+    return lhs |<=| rhs
+}
+
+@discardableResult public func |<=| (lhs: EdgeAnchors, rhs: LayoutExpression<EdgeAnchors, CGFloat>) -> ConstraintGroup {
     return lhs.finalize(constraintsLessThanOrEqualToEdges: rhs.anchor, constant: rhs.constant, priority: rhs.priority)
 }
 
 @discardableResult public func <= (lhs: EdgeAnchors, rhs: LayoutExpression<EdgeAnchors, EdgeInsets>) -> ConstraintGroup {
+    return lhs |<=| rhs
+}
+
+@discardableResult public func |<=| (lhs: EdgeAnchors, rhs: LayoutExpression<EdgeAnchors, EdgeInsets>) -> ConstraintGroup {
     return lhs.finalize(constraintsLessThanOrEqualToEdges: rhs.anchor, insets: rhs.constant, priority: rhs.priority)
 }
 
 @discardableResult public func <= <T, U>(lhs: AnchorPair<T, U>, rhs: AnchorPair<T, U>) -> ConstraintPair {
+    return lhs |<=| rhs
+}
+
+@discardableResult public func |<=| <T, U>(lhs: AnchorPair<T, U>, rhs: AnchorPair<T, U>) -> ConstraintPair {
     return lhs.finalize(constraintsLessThanOrEqualToEdges: rhs)
 }
 
 @discardableResult public func <= <T, U>(lhs: AnchorPair<T, U>, rhs: LayoutExpression<AnchorPair<T, U>, CGFloat>) -> ConstraintPair {
+    return lhs |<=| rhs
+}
+
+@discardableResult public func |<=| <T, U>(lhs: AnchorPair<T, U>, rhs: LayoutExpression<AnchorPair<T, U>, CGFloat>) -> ConstraintPair {
     return lhs.finalize(constraintsLessThanOrEqualToEdges: rhs.anchor, constant: rhs.constant, priority: rhs.priority)
 }
 
 @discardableResult public func <= (lhs: AnchorPair<NSLayoutDimension, NSLayoutDimension>, rhs: CGSize) -> ConstraintPair {
+    return lhs |<=| rhs
+}
+
+@discardableResult public func |<=| (lhs: AnchorPair<NSLayoutDimension, NSLayoutDimension>, rhs: CGSize) -> ConstraintPair {
     return lhs.finalize(constraintsLessThanOrEqualToConstant: rhs)
 }
 
 @discardableResult public func <= (lhs: AnchorPair<NSLayoutDimension, NSLayoutDimension>, rhs: LayoutExpression<AnchorPair<NSLayoutDimension, NSLayoutDimension>, CGSize>) -> ConstraintPair {
+    return lhs |<=| rhs
+}
+
+@discardableResult public func |<=| (lhs: AnchorPair<NSLayoutDimension, NSLayoutDimension>, rhs: LayoutExpression<AnchorPair<NSLayoutDimension, NSLayoutDimension>, CGSize>) -> ConstraintPair {
     return lhs.finalize(constraintsLessThanOrEqualToConstant: rhs.constant, priority: rhs.priority)
 }
 
+infix operator |>=|: ComparisonPrecedence
+
 @discardableResult public func >= <T: BinaryFloatingPoint>(lhs: NSLayoutDimension, rhs: T) -> NSLayoutConstraint {
+    return lhs |>=| rhs
+}
+
+@discardableResult public func |>=| <T: BinaryFloatingPoint>(lhs: NSLayoutDimension, rhs: T) -> NSLayoutConstraint {
     return finalize(constraint: lhs.constraint(greaterThanOrEqualToConstant: CGFloat(rhs)))
 }
 
 @discardableResult public func >= (lhs: NSLayoutXAxisAnchor, rhs: NSLayoutXAxisAnchor) -> NSLayoutConstraint {
+    return lhs |>=| rhs
+}
+
+@discardableResult public func |>=| (lhs: NSLayoutXAxisAnchor, rhs: NSLayoutXAxisAnchor) -> NSLayoutConstraint {
     return finalize(constraint: lhs.constraint(greaterThanOrEqualTo: rhs))
 }
 
 @discardableResult public func >= (lhs: NSLayoutYAxisAnchor, rhs: NSLayoutYAxisAnchor) -> NSLayoutConstraint {
+    return lhs |>=| rhs
+}
+
+@discardableResult public func |>=| (lhs: NSLayoutYAxisAnchor, rhs: NSLayoutYAxisAnchor) -> NSLayoutConstraint {
     return finalize(constraint: lhs.constraint(greaterThanOrEqualTo: rhs))
 }
 
 @discardableResult public func >= (lhs: NSLayoutDimension, rhs: NSLayoutDimension) -> NSLayoutConstraint {
+    return lhs |>=| rhs
+}
+
+@discardableResult public func |>=| (lhs: NSLayoutDimension, rhs: NSLayoutDimension) -> NSLayoutConstraint {
     return finalize(constraint: lhs.constraint(greaterThanOrEqualTo: rhs))
 }
 
 @discardableResult public func >= (lhs: NSLayoutXAxisAnchor, rhs: LayoutExpression<NSLayoutXAxisAnchor, CGFloat>) -> NSLayoutConstraint {
+    return lhs |>=| rhs
+}
+
+@discardableResult public func |>=| (lhs: NSLayoutXAxisAnchor, rhs: LayoutExpression<NSLayoutXAxisAnchor, CGFloat>) -> NSLayoutConstraint {
     return finalize(constraint: lhs.constraint(greaterThanOrEqualTo: rhs.anchor!, multiplier: rhs.multiplier, constant: rhs.constant), withPriority: rhs.priority)
 }
 
 @discardableResult public func >= (lhs: NSLayoutYAxisAnchor, rhs: LayoutExpression<NSLayoutYAxisAnchor, CGFloat>) -> NSLayoutConstraint {
+    return lhs |>=| rhs
+}
+
+@discardableResult public func |>=| (lhs: NSLayoutYAxisAnchor, rhs: LayoutExpression<NSLayoutYAxisAnchor, CGFloat>) -> NSLayoutConstraint {
     return finalize(constraint: lhs.constraint(greaterThanOrEqualTo: rhs.anchor!, multiplier: rhs.multiplier, constant: rhs.constant), withPriority: rhs.priority)
 }
 
 @discardableResult public func >= (lhs: NSLayoutDimension, rhs: LayoutExpression<NSLayoutDimension, CGFloat>) -> NSLayoutConstraint {
+    return lhs |>=| rhs
+}
+
+@discardableResult public func |>=| (lhs: NSLayoutDimension, rhs: LayoutExpression<NSLayoutDimension, CGFloat>) -> NSLayoutConstraint {
     if let anchor = rhs.anchor {
         return finalize(constraint: lhs.constraint(greaterThanOrEqualTo: anchor, multiplier: rhs.multiplier, constant: rhs.constant), withPriority: rhs.priority)
     }
@@ -200,30 +346,58 @@ extension NSLayoutAnchor: LayoutAnchorType {}
 }
 
 @discardableResult public func >= (lhs: EdgeAnchors, rhs: EdgeAnchors) -> ConstraintGroup {
+    return lhs |>=| rhs
+}
+
+@discardableResult public func |>=| (lhs: EdgeAnchors, rhs: EdgeAnchors) -> ConstraintGroup {
     return lhs.finalize(constraintsGreaterThanOrEqualToEdges: rhs)
 }
 
 @discardableResult public func >= (lhs: EdgeAnchors, rhs: LayoutExpression<EdgeAnchors, CGFloat>) -> ConstraintGroup {
+    return lhs |>=| rhs
+}
+
+@discardableResult public func |>=| (lhs: EdgeAnchors, rhs: LayoutExpression<EdgeAnchors, CGFloat>) -> ConstraintGroup {
     return lhs.finalize(constraintsGreaterThanOrEqualToEdges: rhs.anchor, constant: rhs.constant, priority: rhs.priority)
 }
 
 @discardableResult public func >= (lhs: EdgeAnchors, rhs: LayoutExpression<EdgeAnchors, EdgeInsets>) -> ConstraintGroup {
+    return lhs |>=| rhs
+}
+
+@discardableResult public func |>=| (lhs: EdgeAnchors, rhs: LayoutExpression<EdgeAnchors, EdgeInsets>) -> ConstraintGroup {
     return lhs.finalize(constraintsGreaterThanOrEqualToEdges: rhs.anchor, insets: rhs.constant, priority: rhs.priority)
 }
 
 @discardableResult public func >= <T, U>(lhs: AnchorPair<T, U>, rhs: AnchorPair<T, U>) -> ConstraintPair {
+    return lhs |>=| rhs
+}
+
+@discardableResult public func |>=| <T, U>(lhs: AnchorPair<T, U>, rhs: AnchorPair<T, U>) -> ConstraintPair {
     return lhs.finalize(constraintsGreaterThanOrEqualToEdges: rhs)
 }
 
 @discardableResult public func >= <T, U>(lhs: AnchorPair<T, U>, rhs: LayoutExpression<AnchorPair<T, U>, CGFloat>) -> ConstraintPair {
+    return lhs |>=| rhs
+}
+
+@discardableResult public func |>=| <T, U>(lhs: AnchorPair<T, U>, rhs: LayoutExpression<AnchorPair<T, U>, CGFloat>) -> ConstraintPair {
     return lhs.finalize(constraintsGreaterThanOrEqualToEdges: rhs.anchor, constant: rhs.constant, priority: rhs.priority)
 }
 
 @discardableResult public func >= (lhs: AnchorPair<NSLayoutDimension, NSLayoutDimension>, rhs: CGSize) -> ConstraintPair {
+    return lhs |>=| rhs
+}
+
+@discardableResult public func |>=| (lhs: AnchorPair<NSLayoutDimension, NSLayoutDimension>, rhs: CGSize) -> ConstraintPair {
     return lhs.finalize(constraintsGreaterThanOrEqualToConstant: rhs)
 }
 
 @discardableResult public func >= (lhs: AnchorPair<NSLayoutDimension, NSLayoutDimension>, rhs: LayoutExpression<AnchorPair<NSLayoutDimension, NSLayoutDimension>, CGSize>) -> ConstraintPair {
+    return lhs |>=| rhs
+}
+
+@discardableResult public func |>=| (lhs: AnchorPair<NSLayoutDimension, NSLayoutDimension>, rhs: LayoutExpression<AnchorPair<NSLayoutDimension, NSLayoutDimension>, CGSize>) -> ConstraintPair {
     return lhs.finalize(constraintsGreaterThanOrEqualToConstant: rhs.constant, priority: rhs.priority)
 }
 


### PR DESCRIPTION
This PR aims to solve the issue of slow type-checking performance due to operator overloading (see #83).

To solve this, I've added new custom operators that provide the same functionality as the overloaded operators. Essentially, users can opt in by surrounding the overloaded operators in a "box of shame" (thanks, Zev):

| Operator | New Alternative |
|------|----------|
| `==` | ~`\|==\|`~ (changed to `/==/`) |
| `<=` | ~`\|<=\|`~ (changed to `/<=/`) |
| `>=` | ~`\|>=\|`~ (changed to `/>=/`) |

This has a few benefits:
* By using a custom operator rather than overloading existing operators, we reduce the amount of overhead accrued.
* The existing operator overloads now fall back on the new operator alternatives, which prevents duplicated code and makes this PR non-breaking.

---

Here's a build timing summary for an app that makes heavy use of Anchorage:

```
Build Timing Summary

CompileC (799 tasks) | 1121.137 seconds
CompileSwiftSources (49 tasks) | 723.882 seconds
CompileAssetCatalog (7 tasks) | 329.057 seconds
CompileXIB (3 tasks) | 263.134 seconds
Ld (74 tasks) | 89.242 seconds
CompileStoryboard (4 tasks) | 59.476 seconds
CopyPNGFile (60 tasks) | 51.361 seconds
PhaseScriptExecution (4 tasks) | 10.858 seconds
ValidateEmbeddedBinary (5 tasks) | 8.584 seconds
IntentDefinitionCompile (3 tasks) | 6.932 seconds
Ditto (367 tasks) | 6.898 seconds
CodeSign (6 tasks) | 6.889 seconds
IntentDefinitionCodegen (3 tasks) | 6.850 seconds
CreateUniversalBinary (35 tasks) | 4.496 seconds
Touch (36 tasks) | 4.284 seconds
LinkStoryboards (3 tasks) | 0.042 seconds
Libtool (2 tasks) | 0.021 seconds
```

Here's the build timing summary after switching to this branch using my new operators:
```
Build Timing Summary

CompileC (799 tasks) | 1005.547 seconds
CompileSwiftSources (49 tasks) | 682.290 seconds
Ld (74 tasks) | 128.364 seconds
CompileAssetCatalog (7 tasks) | 16.995 seconds
CompileXIB (3 tasks) | 13.545 seconds
ValidateEmbeddedBinary (5 tasks) | 12.560 seconds
CopyPNGFile (60 tasks) | 10.077 seconds
Ditto (367 tasks) | 8.374 seconds
PhaseScriptExecution (4 tasks) | 7.390 seconds
CompileStoryboard (4 tasks) | 7.034 seconds
CreateUniversalBinary (35 tasks) | 5.416 seconds
IntentDefinitionCompile (3 tasks) | 4.970 seconds
IntentDefinitionCodegen (3 tasks) | 4.910 seconds
CodeSign (6 tasks) | 2.332 seconds
Touch (36 tasks) | 0.860 seconds
LinkStoryboards (3 tasks) | 0.024 seconds
Libtool (2 tasks) | 0.021 seconds
```

Overall, the build time went from 4:55 to 3:22.